### PR TITLE
Fix PeriodicHandler error

### DIFF
--- a/include/ddsrouter/event/EventHandler.hpp
+++ b/include/ddsrouter/event/EventHandler.hpp
@@ -46,8 +46,8 @@ namespace event {
  * Inherit:
  * In order to create child classes, be aware of:
  * - While EventHandler is disabled (unset callback) the event should not repeat.
- *   This is because could lead to a problem if when destroying the EventHandler an event happens.
- *   It will try to access data of a destroyed object, and will crush.
+ *   This is because that could lead to a problem if when destroying the EventHandler an event occurs.
+ *   It will try to access data of a destroyed object, and will crash.
  *   Disable the event listener when \c callback_unset_nts_ is called, and enable it with \c callback_set_nts_
  * - TIP: avoid setting listeners in constructor or unsetting them in destructor. Use \c callback_unset_nts_
  *   and \c callback_set_nts_ instead.
@@ -69,7 +69,7 @@ public:
      * @brief Set the callback, and enable EventHandler if callback was not set
      *
      * If callback is already set, it overwrites it.
-     * If callback is not set yet, it uses this callback in advance and enables the Handler
+     * If callback is not set yet, it uses this callback in advance and enables the Handler.
      *
      * It calls the internal method \c callback_set_ once the callback is set so
      * child classes can add functionality when a callback is set.
@@ -85,7 +85,7 @@ public:
      * It calls the internal method \c callback_unset_ once the callback is unset so
      * child classes can add functionality when a callback is unset.
      *
-     * It waits in \c mutex_ if the callback is being called.
+     * It waits in \c event_mutex_ if the callback is being called.
      */
     void unset_callback() noexcept;
 
@@ -97,8 +97,8 @@ public:
      *
      * @param n : number of events at which this thread will awake
      *
-     * @return \c true if it has exit wait due to number of events
-     * @return \c false if it has exit wait due to other reasons (disable Handler)
+     * @return \c true if exits wait due to number of events
+     * @return \c false if exits wait due to other reasons (disable Handler)
      */
     bool wait_for_event(
             uint32_t n = 1) const noexcept;
@@ -120,9 +120,9 @@ protected:
             Args... args) noexcept;
 
     /**
-     * @brief Do not leave this method until every thread waiting in \c wait_for_event have exited
+     * @brief Do not leave this method until every thread waiting in \c wait_for_event has exited
      *
-     * This method must be called only with \c is_callback_set_ to false, otherwise events could never end.
+     * This method must be called only when \c is_callback_set_ is false, otherwise events could never end.
      */
     void awake_all_waiting_threads_nts_() noexcept;
 
@@ -158,7 +158,7 @@ protected:
      */
     std::atomic<bool> is_callback_set_;
 
-    //! Mutex to block EventHandler execution while lambda is being set or called
+    //! Mutex to block EventHandler execution while lambda is being set/unset or called
     mutable std::recursive_mutex event_mutex_;
 
     /**
@@ -194,8 +194,8 @@ protected:
     static const std::function<void(Args...)> DEFAULT_CALLBACK_;
 };
 
-}         /* namespace event */
-}         /* namespace ddsrouter */
+} /* namespace event */
+} /* namespace ddsrouter */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/include/ddsrouter/event/EventHandler.hpp
+++ b/include/ddsrouter/event/EventHandler.hpp
@@ -28,18 +28,30 @@ namespace event {
 
 /**
  * This class is an interface for any class that implements a handler of any kind of event.
- *
  * Consider an event every signal that a process can receive externally.
  * For example: signals, file updates, periodic alarms, etc.
- *
  * Consider a Handler a class that listens for one of these events, and at the moment of the event it raises a
  * previously set callback.
  *
  * This class implements the main methods for every Event Handler.
+ * Setting a callback enables the handler.
+ * Unsetting a callback disables the handler.
  *
  * It also implements a wait method that will make a thread passively wait for n events of a specific kind.
+ * These threads will exit if the number of threads has been reached (since they are active) or if the
+ * EventHandler object is disabled.
  *
  * It is a template regarding the arguments that the Event Handler needs in its callback.
+ *
+ * Inherit:
+ * In order to create child classes, be aware of:
+ * - While EventHandler is disabled (unset callback) the event should not repeat.
+ *   This is because could lead to a problem if when destroying the EventHandler an event happens.
+ *   It will try to access data of a destroyed object, and will crush.
+ *   Disable the event listener when \c callback_unset_nts_ is called, and enable it with \c callback_set_nts_
+ * - TIP: avoid setting listeners in constructor or unsetting them in destructor. Use \c callback_unset_nts_
+ *   and \c callback_set_nts_ instead.
+ * - WARNING: always implement destructor in childs and call \c unset_callback
  */
 template <typename ... Args>
 class EventHandler
@@ -54,26 +66,10 @@ public:
     EventHandler();
 
     /**
-     * @brief Construct an EventHandler with a specific callback.
-     *
-     * @param callback : function that will be called when the event raises.
-     */
-    EventHandler(
-            std::function<void(Args...)> callback);
-
-    /**
-     * @brief Destroy the Event Handler object if it is not being executed
-     *
-     * Stop if \c mutex_ is taken until the event callback has been executed, and after
-     * it destroy the object.
-     */
-    ~EventHandler();
-
-    /**
-     * @brief Set the callback
+     * @brief Set the callback, and enable EventHandler if callback was not set
      *
      * If callback is already set, it overwrites it.
-     * If callback is not set yet, it uses this callback in advance.
+     * If callback is not set yet, it uses this callback in advance and enables the Handler
      *
      * It calls the internal method \c callback_set_ once the callback is set so
      * child classes can add functionality when a callback is set.
@@ -84,10 +80,12 @@ public:
             std::function<void(Args...)> callback) noexcept;
 
     /**
-     * @brief Unset the callback and set this object as if it had no callback
+     * @brief Unset the callback and set this object as disabled
      *
      * It calls the internal method \c callback_unset_ once the callback is unset so
      * child classes can add functionality when a callback is unset.
+     *
+     * It waits in \c mutex_ if the callback is being called.
      */
     void unset_callback() noexcept;
 
@@ -98,8 +96,11 @@ public:
      * Otherwise, it could get stuck if the event occurs before this wait.
      *
      * @param n : number of events at which this thread will awake
+     *
+     * @return \c true if it has exit wait due to number of events
+     * @return \c false if it has exit wait due to other reasons (disable Handler)
      */
-    void wait_for_event(
+    bool wait_for_event(
             uint32_t n = 1) const noexcept;
 
     //! Simulate as if the event had occurred
@@ -109,7 +110,7 @@ public:
 protected:
 
     /**
-     * @brief Call callback function
+     * @brief Call callback function if Handler enabled
      *
      * This method will be called every time the event occurs or by calling \c force_callback
      *
@@ -119,50 +120,82 @@ protected:
             Args... args) noexcept;
 
     /**
+     * @brief Do not leave this method until every thread waiting in \c wait_for_event have exited
+     *
+     * This method must be called only with \c is_callback_set_ to false, otherwise events could never end.
+     */
+    void awake_all_waiting_threads_nts_() noexcept;
+
+    /**
      * Protected method to overwrite in child classes if specific functionality is required
      * when a new callback is set.
      *
      * If it is not overwritten, it does nothing.
+     *
+     * It is already guarded by \c event_mutex_ .
      */
-    virtual void callback_set_() noexcept;
+    virtual void callback_set_nts_() noexcept;
 
     /**
      * Protected method to overwrite in child classes if specific functionality is required
      * when a new callback is unset.
      *
      * If it is not overwritten, it does nothing.
+     *
+     * It is already guarded by \c event_mutex_ .
      */
-    virtual void callback_unset_() noexcept;
+    virtual void callback_unset_nts_() noexcept;
 
     //! Internal callback reference
     std::function<void(Args...)> callback_;
 
-    //! Number of times the event has occurred so far
-    std::atomic<uint32_t> number_of_events_registered_;
-
-    //! Whether the callback of this Handler is set
+    /**
+     * @brief Whether the callback of this Handler is set
+     *
+     * This variable also references the enable/disable status of the EventHandler.
+     *
+     * Guard by \c wait_mutex_
+     */
     std::atomic<bool> is_callback_set_;
 
-    //! Mutex to block event execution while lambda is being set or called
-    mutable std::recursive_mutex mutex_;
+    //! Mutex to block EventHandler execution while lambda is being set or called
+    mutable std::recursive_mutex event_mutex_;
 
     /**
-     * @brief Default callback. It shows a warning that callback is not set
+     * @brief Number of times the event has occurred so far
      *
-     * @note This callback should never be called as the callback is not called
-     * unless \c is_callback_set_ is true. However, it is useful for unset callback.
+     * Guard by \c wait_mutex_
      */
-    static const std::function<void(Args...)> DEFAULT_CALLBACK_;
+    std::atomic<uint32_t> number_of_events_registered_;
 
-    //! Condition variable to wait until the event occurs
+    /**
+     * @brief Number of threads that are currently waiting in \c wait_for_event
+     *
+     * Guard by \c wait_mutex_
+     */
+    mutable std::atomic<uint32_t> threads_waiting_;
+
+    /**
+     * @brief Condition variable to wait until the event occurs
+     *
+     * Guard by \c wait_mutex_
+     */
     mutable std::condition_variable wait_condition_variable_;
 
     //! Guard access to \c wait_condition_variable_
     mutable std::mutex wait_mutex_;
+
+    /**
+     * @brief Default callback.
+     *
+     * @note This callback should never be called as the callback is not called
+     * unless \c is_callback_set_ is true. However, it is useful for constructor without callback
+     */
+    static const std::function<void(Args...)> DEFAULT_CALLBACK_;
 };
 
-} /* namespace event */
-} /* namespace ddsrouter */
+}         /* namespace event */
+}         /* namespace ddsrouter */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/include/ddsrouter/event/EventHandler.hpp
+++ b/include/ddsrouter/event/EventHandler.hpp
@@ -20,6 +20,7 @@
 #define _DDSROUTER_EVENT_EVENTHANDLER_HPP_
 
 #include <functional>
+#include <mutex>
 
 namespace eprosima {
 namespace ddsrouter {
@@ -59,6 +60,14 @@ public:
      */
     EventHandler(
             std::function<void(Args...)> callback);
+
+    /**
+     * @brief Destroy the Event Handler object if it is not being executed
+     *
+     * Stop if \c mutex_ is taken until the event callback has been executed, and after
+     * it destroy the object.
+     */
+    ~EventHandler();
 
     /**
      * @brief Set the callback
@@ -133,6 +142,9 @@ protected:
 
     //! Whether the callback of this Handler is set
     std::atomic<bool> is_callback_set_;
+
+    //! Mutex to block event execution while lambda is being set or called
+    mutable std::recursive_mutex mutex_;
 
     /**
      * @brief Default callback. It shows a warning that callback is not set

--- a/include/ddsrouter/event/FileWatcherHandler.hpp
+++ b/include/ddsrouter/event/FileWatcherHandler.hpp
@@ -64,7 +64,7 @@ public:
     /**
      * @brief Destroy the File Watcher Handler object
      *
-     * Stop file watching
+     * Calls \c unset_callback
      */
     ~FileWatcherHandler();
 
@@ -77,20 +77,41 @@ protected:
      *
      * @note Method called only from constructor
      */
-    void start_filewatcher_();
+    void start_filewatcher_nts_();
 
     /**
      * @brief Stop watching file
      *
      * @note Method called only from destructor
      */
-    void stop_filewatcher_();
+    void stop_filewatcher_nts_();
+
+    /**
+     * @brief Override \c callback_set_ from \c EventHandler .
+     *
+     * It starts filewatcher if it has not been started.
+     *
+     * It is already guarded by \c event_mutex_ .
+     */
+    virtual void callback_set_nts_() noexcept override;
+
+    /**
+     * @brief Override \c callback_set_ from \c EventHandler .
+     *
+     * It stops filewatcher if it has been started.
+     *
+     * It is already guarded by \c event_mutex_ .
+     */
+    virtual void callback_unset_nts_() noexcept override;
 
     //! Path of file to watch
     std::string file_path_;
 
     //! File Watcher object
     std::unique_ptr<filewatch::FileWatch<std::string>> file_watch_handler_;
+
+    //! Whether the file_watcher has already been started
+    std::atomic<bool> filewatcher_started_;
 };
 
 } /* namespace event */

--- a/include/ddsrouter/event/PeriodicEventHandler.hpp
+++ b/include/ddsrouter/event/PeriodicEventHandler.hpp
@@ -19,6 +19,7 @@
 #ifndef _DDSROUTER_EVENT_PERIODICEVENTHANDLER_HPP_
 #define _DDSROUTER_EVENT_PERIODICEVENTHANDLER_HPP_
 
+#include <atomic>
 #include <functional>
 #include <thread>
 
@@ -92,6 +93,9 @@ protected:
 
     //! Period thread
     std::thread period_thread_;
+
+    //! Whether the event loop must keep running
+    std::atomic<bool> active_;
 };
 
 } /* namespace event */

--- a/include/ddsrouter/event/SignalHandler.hpp
+++ b/include/ddsrouter/event/SignalHandler.hpp
@@ -32,7 +32,7 @@ namespace event {
 //! Available data types for SignalHandler class
 enum Signals
 {
-    SIGNAL_SIGINT = SIGINT, //! SIGINT = C^
+    SIGNAL_SIGINT = SIGINT, //! SIGINT = ^C
 };
 
 /**
@@ -55,7 +55,7 @@ class SignalHandler : public EventHandler<int>
 public:
 
     /**
-     * @brief Default constructor
+     * @brief Default constructor that intialized the EventHandler with a default callback.
      *
      * It is initialized with a callback that only prints a Log message when the signal has arrived.
      *
@@ -63,6 +63,8 @@ public:
      * This default callback only logs that a signal has been received.
      *
      * @note Adds \c this to a static list of active \c SignalHandlers .
+     *
+     * @warning Default callback is set in this constructor, so EventHandler is enabled.
      */
     SignalHandler() noexcept;
 
@@ -80,6 +82,8 @@ public:
     /**
      * @brief Destroy Signal Handler object
      *
+     * Calls \c unset_callback
+     *
      * @note It eliminates \c this from static list of \c SignalHandlers .
      * If it is the last one, unset the static signal handler function.
      */
@@ -88,10 +92,10 @@ public:
 protected:
 
     //! Specific set method that adds \c this to \c active_handlers_
-    void callback_set_() noexcept override;
+    void callback_set_nts_() noexcept override;
 
     //! Specific set method that removes \c this from \c active_handlers_
-    void callback_unset_() noexcept override;
+    void callback_unset_nts_() noexcept override;
 
     //! Add \c this to the active handlers list. Called when callback is set.
     void add_to_active_handlers_() noexcept;

--- a/include/ddsrouter/event/impl/EventHandler.ipp
+++ b/include/ddsrouter/event/impl/EventHandler.ipp
@@ -160,7 +160,7 @@ void EventHandler<Args...>::awake_all_waiting_threads_nts_() noexcept
 {
     bool exit = false;
 
-    while(!exit)
+    while (!exit)
     {
         wait_condition_variable_.notify_all();
         {

--- a/include/ddsrouter/event/impl/EventHandler.ipp
+++ b/include/ddsrouter/event/impl/EventHandler.ipp
@@ -52,9 +52,17 @@ EventHandler<Args...>::EventHandler(
 }
 
 template <typename ... Args>
+EventHandler<Args...>::~EventHandler()
+{
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+}
+
+template <typename ... Args>
 void EventHandler<Args...>::set_callback(
         std::function<void(Args...)> callback) noexcept
 {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
     is_callback_set_.store(true);
     callback_ = callback;
     callback_set_();
@@ -63,6 +71,8 @@ void EventHandler<Args...>::set_callback(
 template <typename ... Args>
 void EventHandler<Args...>::unset_callback() noexcept
 {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
     is_callback_set_.store(false);
     callback_ = DEFAULT_CALLBACK_;
     callback_unset_();
@@ -93,6 +103,8 @@ template <typename ... Args>
 void EventHandler<Args...>::event_occurred_(
         Args... args) noexcept
 {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+
     {
         // Lock to avoid changing values while wait is processing condition
         std::lock_guard<std::mutex> lock(wait_mutex_);

--- a/include/ddsrouter/event/impl/EventHandler.ipp
+++ b/include/ddsrouter/event/impl/EventHandler.ipp
@@ -53,7 +53,7 @@ void EventHandler<Args...>::set_callback(
     std::lock_guard<std::recursive_mutex> lock(event_mutex_);
 
     {
-        // setting callback
+        // Setting callback
         // Wait mutex must be taken because this variable is used in wait_for_event() wait
         std::lock_guard<std::mutex> lock(wait_mutex_);
         is_callback_set_.store(true);
@@ -73,7 +73,7 @@ void EventHandler<Args...>::unset_callback() noexcept
     if (is_callback_set_)
     {
         {
-            // unsetting callback
+            // Unsetting callback
             // Wait mutex must be taken because this variable is used in wait_for_event() wait
             std::unique_lock<std::mutex> lock(wait_mutex_);
             is_callback_set_.store(false);
@@ -90,7 +90,7 @@ void EventHandler<Args...>::unset_callback() noexcept
     }
     else
     {
-        logWarning(DDSROUTER_HANDLER, "Unsetting callback from an EventHandler that had yet no callback set.")
+        logWarning(DDSROUTER_HANDLER, "Unsetting callback from an EventHandler that had no callback set.")
     }
 }
 
@@ -116,7 +116,7 @@ bool EventHandler<Args...>::wait_for_event(
         --threads_waiting_;
     }
 
-    // Return true if the condition has been fulfilled. It could stop due to a unset callback
+    // Return true if the condition has been fulfilled. It could stop due to an unset callback
     // Note: number_of_events_registered_ does not required a mutex because it is being read and it is atomic
     return number_of_events_registered_.load() >= n;
 }

--- a/include/ddsrouter/event/impl/SignalHandler.ipp
+++ b/include/ddsrouter/event/impl/SignalHandler.ipp
@@ -42,7 +42,7 @@ SignalHandler<SigNum>::SignalHandler() noexcept
         [](int signum)
         {
             logInfo(DDSROUTER_SIGNALHANDLER,
-            "Received signal " << signum << " in specific handler .");
+            "Received signal " << signum << " in specific handler.");
         })
 {
 }
@@ -50,25 +50,25 @@ SignalHandler<SigNum>::SignalHandler() noexcept
 template <int SigNum>
 SignalHandler<SigNum>::SignalHandler(
         std::function<void(int)> callback) noexcept
-    : EventHandler<int>(callback)
+    : EventHandler<int>()
 {
-    add_to_active_handlers_();
+    set_callback(callback);
 }
 
 template <int SigNum>
 SignalHandler<SigNum>::~SignalHandler()
 {
-    erase_from_active_handlers_();
+    unset_callback();
 }
 
 template <int SigNum>
-void SignalHandler<SigNum>::callback_set_() noexcept
+void SignalHandler<SigNum>::callback_set_nts_() noexcept
 {
     add_to_active_handlers_();
 }
 
 template <int SigNum>
-void SignalHandler<SigNum>::callback_unset_() noexcept
+void SignalHandler<SigNum>::callback_unset_nts_() noexcept
 {
     erase_from_active_handlers_();
 }

--- a/src/cpp/event/FileWatcherHandler.cpp
+++ b/src/cpp/event/FileWatcherHandler.cpp
@@ -57,6 +57,9 @@ void FileWatcherHandler::start_filewatcher_()
             file_path_,
             [this](const std::string& path, const filewatch::Event change_type)
             {
+                // Lock mutex so object is not destroyed while in callback
+                std::lock_guard<std::recursive_mutex> lock(mutex_);
+
                 switch (change_type)
                 {
                     case filewatch::Event::modified:
@@ -80,6 +83,7 @@ void FileWatcherHandler::start_filewatcher_()
 
 void FileWatcherHandler::stop_filewatcher_()
 {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     file_watch_handler_.reset();
 }
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -110,7 +110,6 @@ int main(
                 };
 
         // Creating FileWatcher event handler
-        std::cout << file_path << std::endl;
         std::unique_ptr<event::FileWatcherHandler> file_watcher_handler =
                 std::make_unique<event::FileWatcherHandler>(filewatcher_callback, file_path);
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -75,7 +75,7 @@ int main(
         // First of all, create signal handler so SIGINT does not break the program while initializing
         // Signal handler
         std::unique_ptr<event::SignalHandler<event::SIGNAL_SIGINT>> signal_handler =
-            std::make_unique<event::SignalHandler<event::SIGNAL_SIGINT>>();
+                std::make_unique<event::SignalHandler<event::SIGNAL_SIGINT>>();
 
         /////
         // DDS Router Initialization
@@ -112,7 +112,7 @@ int main(
         // Creating FileWatcher event handler
         std::cout << file_path << std::endl;
         std::unique_ptr<event::FileWatcherHandler> file_watcher_handler =
-            std::make_unique<event::FileWatcherHandler>(filewatcher_callback, file_path);
+                std::make_unique<event::FileWatcherHandler>(filewatcher_callback, file_path);
 
         /////
         // Periodic Handler for reload configuration in periodic time

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -74,7 +74,8 @@ int main(
     {
         // First of all, create signal handler so SIGINT does not break the program while initializing
         // Signal handler
-        event::SignalHandler<event::SIGNAL_SIGINT> signal_handler;
+        std::unique_ptr<event::SignalHandler<event::SIGNAL_SIGINT>> signal_handler =
+            std::make_unique<event::SignalHandler<event::SIGNAL_SIGINT>>();
 
         /////
         // DDS Router Initialization
@@ -109,6 +110,7 @@ int main(
                 };
 
         // Creating FileWatcher event handler
+        std::cout << file_path << std::endl;
         std::unique_ptr<event::FileWatcherHandler> file_watcher_handler =
             std::make_unique<event::FileWatcherHandler>(filewatcher_callback, file_path);
 
@@ -146,7 +148,7 @@ int main(
         router.start();
 
         // Wait until signal arrives
-        signal_handler.wait_for_event();
+        signal_handler->wait_for_event();
 
         // Before stopping the Router erase event handlers that reload configuration
         if (periodic_handler)

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -109,7 +109,8 @@ int main(
                 };
 
         // Creating FileWatcher event handler
-        event::FileWatcherHandler file_watcher_handler(filewatcher_callback, file_path);
+        std::unique_ptr<event::FileWatcherHandler> file_watcher_handler =
+            std::make_unique<event::FileWatcherHandler>(filewatcher_callback, file_path);
 
         /////
         // Periodic Handler for reload configuration in periodic time
@@ -146,6 +147,17 @@ int main(
 
         // Wait until signal arrives
         signal_handler.wait_for_event();
+
+        // Before stopping the Router erase event handlers that reload configuration
+        if (periodic_handler)
+        {
+            periodic_handler.reset();
+        }
+
+        if (file_watcher_handler)
+        {
+            file_watcher_handler.reset();
+        }
 
         // Stop Router
         router.stop();


### PR DESCRIPTION
Fix error in PeriodicHandler so it does not call callback if it has finished.
When reload period is too small, it provokes a segfault because calls DDSRouter when it has been destroyed.

Signed-off-by: jparisu <javierparis@eprosima.com>