### PR TITLE
Add logging info traces to WAN test

### DIFF
--- a/test/blackbox/ddsrouter_core/dds/WAN/DDSTestWAN.cpp
+++ b/test/blackbox/ddsrouter_core/dds/WAN/DDSTestWAN.cpp
@@ -181,6 +181,8 @@ int main(
         int argc,
         char** argv)
 {
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Kind::Info);
+
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
**Test PR
Do not merge!**

This PR has the goal of cheking the output of TLSv4 communication test to see where and when it gets stucked.