### PR TITLE
Track Debugger Timer

### DIFF
--- a/ddsrouter_cmake/README.md
+++ b/ddsrouter_cmake/README.md
@@ -93,16 +93,17 @@ There are default CMake options used within ddsrouter_cmake package that will al
 In case the user sets these variables, they will have that value. Otherwise,
 they will be initialized to their corresponding default value.
 
-| Option Name         | Default value     | Description                                 |
-|---------------------|-------------------|---------------------------------------------|
-| BUILD_TESTS         | OFF               | Build tests                                 |
-| BUILD_DOCS_TESTS    | $BUILD_TESTS      | Build tests only for Documentation packages |
-| BUILD_TOOL_TESTS    | $BUILD_TESTS      | Build tests only for Application packages   |
-| BUILD_LIBRARY_TESTS | $BUILD_TESTS      | Build tests only for Library packages       |
-| BUILD_ALL           | $BUILD_TESTS      | Build package                               |
-| BUILD_DOCS          | $BUILD_DOCS_TESTS | Build only Documentation packages           |
-| BUILD_TOOL          | ON                | Build only Application packages             |
-| BUILD_LIBRARY       | ON                | Build only Library packages                 |
-| CODE_COVERAGE       | OFF               | Activate Code Coverage flags                |
-| CMAKE_BUILD_TYPE    | Release           | CMake Build Type                            |
-| LOG_INFO            | OFF (ON if Debug) | Activate log info verbosity level           |
+| Option Name                   | Default value     | Description                                    |
+|-------------------------------|-------------------|------------------------------------------------|
+| BUILD_TESTS                   | OFF               | Build tests                                    |
+| BUILD_DOCS_TESTS              | $BUILD_TESTS      | Build tests only for Documentation packages    |
+| BUILD_TOOL_TESTS              | $BUILD_TESTS      | Build tests only for Application packages      |
+| BUILD_LIBRARY_TESTS           | $BUILD_TESTS      | Build tests only for Library packages          |
+| BUILD_ALL                     | $BUILD_TESTS      | Build package                                  |
+| BUILD_DOCS                    | $BUILD_DOCS_TESTS | Build only Documentation packages              |
+| BUILD_TOOL                    | ON                | Build only Application packages                |
+| BUILD_LIBRARY                 | ON                | Build only Library packages                    |
+| CODE_COVERAGE                 | OFF               | Activate Code Coverage flags                   |
+| CMAKE_BUILD_TYPE              | Release           | CMake Build Type                               |
+| LOG_INFO                      | OFF (ON if Debug) | Activate log info verbosity level              |
+| EPROSIMA_PERFORMANCE_DEBUG    | OFF               | Activate performance debug classes compilation |

--- a/ddsrouter_cmake/cmake/project/cmake_options.cmake
+++ b/ddsrouter_cmake/cmake/project/cmake_options.cmake
@@ -22,20 +22,22 @@
 #
 # CMAKE OPTIONS ALLOWED
 #
-# - BUILD_TESTS             : OFF
-# - BUILD_DOCS_TESTS        : BUILD_TESTS
-# - BUILD_TOOL_TESTS         : BUILD_TESTS
-# - BUILD_LIBRARY_TESTS     : BUILD_TESTS
+# - BUILD_TESTS                 : OFF
+# - BUILD_DOCS_TESTS            : BUILD_TESTS
+# - BUILD_TOOL_TESTS            : BUILD_TESTS
+# - BUILD_LIBRARY_TESTS         : BUILD_TESTS
 #
-# - BUILD_ALL               : BUILD_TESTS
-# - BUILD_DOCS              : BUILD_DOCS_TESTS
-# - BUILD_TOOL               : ON
-# - BUILD_LIBRARY           : ON
+# - BUILD_ALL                   : BUILD_TESTS
+# - BUILD_DOCS                  : BUILD_DOCS_TESTS
+# - BUILD_TOOL                  : ON
+# - BUILD_LIBRARY               : ON
 #
-# - CODE_COVERAGE           : OFF
-# - CMAKE_BUILD_TYPE        : Release
+# - CODE_COVERAGE               : OFF
+# - CMAKE_BUILD_TYPE            : Release
 #
-# - LOG_INFO                : OFF       // TODO change LOG cmake options to make them smarter
+# - LOG_INFO                    : OFF       // TODO change LOG cmake options to make them smarter
+#
+# - EPROSIMA_PERFORMANCE_DEBUG  : OFF
 #
 # ARGUMENTS:
 # NONE
@@ -95,6 +97,11 @@ macro(configure_cmake_options)
         set(LOG_INFO ON)
     else ()
         set(LOG_INFO CACHE BOOL OFF)
+    endif()
+
+    # PERFORMANCE
+    if (NOT DEFINED EPROSIMA_PERFORMANCE_DEBUG)
+        set(EPROSIMA_PERFORMANCE_DEBUG OFF)
     endif()
 
 endmacro()

--- a/ddsrouter_cmake/templates/cpp/library/config.h.in
+++ b/ddsrouter_cmake/templates/cpp/library/config.h.in
@@ -28,4 +28,7 @@
 #define @MODULE_MACRO@_VERSION_STR "@PROJECT_VERSION@"
 #endif // ifndef @MODULE_MACRO@_VERSION_STR
 
+// Performance
+#cmakedefine EPROSIMA_PERFORMANCE_DEBUG
+
 #endif // ifndef _@MODULE_MACRO@_LIBRARY_CONFIG_H_

--- a/ddsrouter_core/src/cpp/communication/Track.cpp
+++ b/ddsrouter_core/src/cpp/communication/Track.cpp
@@ -43,6 +43,7 @@ Track::Track(
     , enabled_(false)
     , exit_(false)
     , data_available_status_(NO_MORE_DATA)
+    , debug_transmit_timer__(STR_ENTRY << "Track::transmit_ {" << *this << "}")
 {
     logDebug(DDSROUTER_TRACK, "Creating Track " << *this << ".");
 
@@ -201,6 +202,8 @@ void Track::transmit_thread_function_() noexcept
 
 void Track::transmit_() noexcept
 {
+    debug_transmit_timer__.in_execution();
+
     // Loop that ends if it should stop transmitting (should_transmit_nts_).
     // Called inside the loop so it is protected by a mutex that is freed in every iteration.
     while (true)
@@ -263,6 +266,8 @@ void Track::transmit_() noexcept
 
         payload_pool_->release_payload(data->payload);
     }
+
+    debug_transmit_timer__.end_execution();
 }
 
 std::ostream& operator <<(

--- a/ddsrouter_core/src/cpp/communication/Track.hpp
+++ b/ddsrouter_core/src/cpp/communication/Track.hpp
@@ -24,6 +24,8 @@
 #include <mutex>
 #include <thread>
 
+#include <ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp>
+
 #include <participant/IParticipant.hpp>
 #include <reader/IReader.hpp>
 #include <writer/IWriter.hpp>
@@ -252,6 +254,8 @@ protected:
      * Mutex to guard while the Track is sending a message.
      */
     std::mutex on_transmission_mutex_;
+
+    utils::debug::ExecutionTimerDebugger debug_transmit_timer__;
 
     // Allow operator << to use private variables
     friend std::ostream& operator <<(

--- a/ddsrouter_core/src/cpp/writer/implementations/auxiliar/DummyWriter.hpp
+++ b/ddsrouter_core/src/cpp/writer/implementations/auxiliar/DummyWriter.hpp
@@ -22,7 +22,7 @@
 #include <condition_variable>
 #include <mutex>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 
 #include <writer/implementations/auxiliar/BaseWriter.hpp>
 #include <writer/IWriter.hpp>

--- a/ddsrouter_event/include/ddsrouter_event/PeriodicEventHandler.hpp
+++ b/ddsrouter_event/include/ddsrouter_event/PeriodicEventHandler.hpp
@@ -23,7 +23,7 @@
 #include <functional>
 #include <thread>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 #include <ddsrouter_event/EventHandler.hpp>
 #include <ddsrouter_event/library/library_dll.h>
 

--- a/ddsrouter_event/include/ddsrouter_event/wait/WaitHandler.hpp
+++ b/ddsrouter_event/include/ddsrouter_event/wait/WaitHandler.hpp
@@ -24,7 +24,7 @@
 #include <functional>
 #include <mutex>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 
 namespace eprosima {
 namespace ddsrouter {

--- a/ddsrouter_event/include/ddsrouter_event/wait/impl/WaitHandler.ipp
+++ b/ddsrouter_event/include/ddsrouter_event/wait/impl/WaitHandler.ipp
@@ -16,7 +16,7 @@
  */
 
 #include <ddsrouter_utils/Log.hpp>
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 
 #ifndef _DDSROUTEREVENT_WAIT_IMPL_WAITHANDLER_IPP_
 #define _DDSROUTEREVENT_WAIT_IMPL_WAITHANDLER_IPP_

--- a/ddsrouter_event/test/unittest/periodic_event/PeriodicEventHandlerTest.cpp
+++ b/ddsrouter_event/test/unittest/periodic_event/PeriodicEventHandlerTest.cpp
@@ -21,7 +21,7 @@
 
 #include <TestLogHandler.hpp>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/Timer.hpp>
 #include <ddsrouter_utils/Log.hpp>
 #include <ddsrouter_utils/exception/InitializationException.hpp>
 

--- a/ddsrouter_utils/include/ddsrouter_utils/Formatter.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/Formatter.hpp
@@ -53,6 +53,9 @@ public:
     //! Return a string with the concatenation of this object
     DDSROUTER_UTILS_DllAPI std::string to_string() const noexcept;
 
+    //! Cast operator to implicitly cast a \c Formatter to a \c std::string
+    DDSROUTER_UTILS_DllAPI operator std::string() const noexcept;
+
 protected:
 
     //! Concatenated stream where the streams are added at the end

--- a/ddsrouter_utils/include/ddsrouter_utils/Log.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/Log.hpp
@@ -57,6 +57,13 @@ using LogConsumer = eprosima::fastdds::dds::LogConsumer;
  */
 #define logUser(cat, msg) std::cout /* << STRINGIFY(cat) << " : " */ << msg << std::endl;
 
+/**
+ * @brief Log level only for debug performance
+ *
+ * @note As this level is not implemented, it is used as Warning level.
+ */
+#define logPerformance(cat, msg) logPerformance_(cat, msg)
+
 // Allow multiconfig platforms like windows to disable info queueing on Release and other non-debug configs
 #if !HAVE_LOG_NO_INFO &&  \
     (defined(FASTDDS_ENFORCE_LOG_INFO) || \
@@ -116,6 +123,32 @@ using LogConsumer = eprosima::fastdds::dds::LogConsumer;
 #else
 #define logDevError_(cat, msg)
 #endif // ifndef LOG_NO_INFO
+
+#if EPROSIMA_PERFORMANCE_DEBUG
+#define logPerformance_(cat, msg)                                                                                       \
+    {                                                                                                               \
+        using namespace eprosima::fastdds::dds;                                                                     \
+        if (Log::GetVerbosity() >= Log::Kind::Warning)                                                              \
+        {                                                                                                           \
+            std::stringstream fastdds_log_ss_tmp__;                                                                 \
+            fastdds_log_ss_tmp__ << "PERFORMANCE: " msg;                                                                            \
+            Log::QueueLog(                                                                                          \
+                fastdds_log_ss_tmp__.str(), Log::Context{__FILE__, __LINE__, __func__, #cat}, Log::Kind::Warning);  \
+        }                                                                                                           \
+    }
+#elif (__INTERNALDEBUG || _INTERNALDEBUG)
+#define logPerformance_(cat, msg)                                   \
+    {                                                           \
+        auto fastdds_log_lambda_tmp__ = [&]()                   \
+                {                                               \
+                    std::stringstream fastdds_log_ss_tmp__;     \
+                    fastdds_log_ss_tmp__ << msg;                \
+                };                                              \
+        (void)fastdds_log_lambda_tmp__;                         \
+    }
+#else
+#define logPerformance_(cat, msg)
+#endif // if EPROSIMA_PERFORMANCE_DEBUG
 
 } /* namespace utils */
 } /* namespace ddsrouter */

--- a/ddsrouter_utils/include/ddsrouter_utils/Log.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/Log.hpp
@@ -124,7 +124,7 @@ using LogConsumer = eprosima::fastdds::dds::LogConsumer;
 #define logDevError_(cat, msg)
 #endif // ifndef LOG_NO_INFO
 
-#if EPROSIMA_PERFORMANCE_DEBUG
+#ifdef EPROSIMA_PERFORMANCE_DEBUG
 #define logPerformance_(cat, msg)                                                                                       \
     {                                                                                                               \
         using namespace eprosima::fastdds::dds;                                                                     \

--- a/ddsrouter_utils/include/ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp
@@ -42,7 +42,7 @@ namespace debug {
  * use and to implement.
  */
 
-#if EPROSIMA_PERFORMANCE_DEBUG
+#ifdef EPROSIMA_PERFORMANCE_DEBUG
 
 /**
  * TODO

--- a/ddsrouter_utils/include/ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp
@@ -1,0 +1,90 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ExecutionTimerDebugger.hpp
+ */
+
+#ifndef _DDSROUTERUTILS_EFFICIENCYDEBUGGER_EXECUTIONTIMERDEBUGGER_HPP_
+#define _DDSROUTERUTILS_EFFICIENCYDEBUGGER_EXECUTIONTIMERDEBUGGER_HPP_
+
+#include <string>
+
+#include <ddsrouter_utils/time/ProportionalTimer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+namespace debug {
+
+/*
+ * The idea behind the class implemented in this file is to measure how much time is a class or function
+ * is executed in comparison with the total time of the class existing.
+ *
+ * It is thought to be the most efficiency possible when \c EPROSIMA_PERFORMANCE_DEBUG is not defined, by
+ * implemented an empty class (compiler optimizes it) and the methods do anything.
+ *
+ * NOTE: There was another way to do this, by forcing the user to create and use this class from macros,
+ * in a way that each macro is empty when \c EPROSIMA_PERFORMANCE_DEBUG is not defined, and call what it must
+ * call otherwise.
+ * This was proben to be a bit more efficient than the current way (just a bit) but much more difficult to
+ * use and to implement.
+ */
+
+#if EPROSIMA_PERFORMANCE_DEBUG
+
+/**
+ * TODO
+ */
+class ExecutionTimerDebugger
+{
+public:
+
+    ExecutionTimerDebugger(const std::string& debugger_name);
+
+    ~ExecutionTimerDebugger();
+
+    void in_execution();
+
+    void end_execution();
+
+protected:
+
+    ProportionalTimer timer_;
+    std::string debugger_name_;
+};
+
+#else
+
+/**
+ * Empty class that does not do anything and has no variables (so compiler does not create it)
+ * Reimplement the methods from \c ExecutionTimerDebugger so the do not do anything and thus
+ * the call is very fast even when no using class.
+ */
+class ExecutionTimerDebugger
+{
+public:
+    ExecutionTimerDebugger(const std::string& ) {}
+    inline void in_execution() {}
+    inline void end_execution() {}
+};
+
+#endif // if EPROSIMA_PERFORMANCE_DEBUG
+
+} /* namespace debug */
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */
+
+#endif /* _DDSROUTERUTILS_EFFICIENCYDEBUGGER_EXECUTIONTIMERDEBUGGER_HPP_ */

--- a/ddsrouter_utils/include/ddsrouter_utils/time/PausableTimer.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/time/PausableTimer.hpp
@@ -1,0 +1,105 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PausableTimer.hpp
+ */
+
+#ifndef _DDSROUTERUTILS_PAUSABLETIMER_HPP_
+#define _DDSROUTERUTILS_PAUSABLETIMER_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <ddsrouter_utils/library/library_dll.h>
+#include <ddsrouter_utils/time/Timer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+/**
+ * @brief Class to measure time elapsed and allow to pause and replay it.
+ *
+ * This class has 2 states, paused and playing.
+ * It stores internally the amount of time that has been elapsed while the timer is playing.
+ *
+ * @note the internal \c Timer parent class actually counts the time since the state has changed.
+ */
+class PausableTimer : public Timer
+{
+public:
+
+    /**
+     * @brief Create a new Timer which stores the time it has been created
+     *
+     * @param play whether the times should start playing or else paused
+     */
+    DDSROUTER_UTILS_DllAPI PausableTimer(bool play) noexcept;
+
+    /**
+     * @brief Replay a paused Timer.
+     *
+     * If already playing, do nothing.
+     */
+    DDSROUTER_UTILS_DllAPI void play() noexcept;
+
+    /**
+     * @brief Pause the timer. Time while paused does not count as elapsed.
+     *
+     * If already paused, do nothing
+     */
+    DDSROUTER_UTILS_DllAPI void pause() noexcept;
+
+    //! Elapsed time in milliseconds with object playing
+    DDSROUTER_UTILS_DllAPI double elapsed() const noexcept override;
+
+    /**
+     * @brief  Reset timer initial time to the moment \c reset is called.
+     *
+     * It also reset the internal counter value, so it starts from 0 as if it was created at this moment.
+     */
+    DDSROUTER_UTILS_DllAPI void reset() noexcept override;
+
+    //! Whether the timer is playing or paused
+    DDSROUTER_UTILS_DllAPI bool playing() const noexcept;
+
+protected:
+
+    /**
+     * @brief Reset the parent class timer but do not reset stored time.
+     *
+     * This method is used when timer is paused, so the timer indicates the time since last
+     * pause / play has been called, but the stored timer is not affected.
+     */
+    void reset_() noexcept;
+
+    //! Whether the timer is paused or not
+    std::atomic<bool> playing_;
+
+    /**
+     * @brief Time elapsed while object has been playing
+     *
+     * This object is used to store the time it has been elapsed while object
+     * has being playing in previous plays. It does not store the current time if currently playing.
+     *
+     * This value (plus the amount of time elapsed in case of currently playing) is the amount of time elapsed.
+     */
+    double stored_time_elapsed_;
+};
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */
+
+#endif /* _DDSROUTERUTILS_PAUSABLETIMER_HPP_ */

--- a/ddsrouter_utils/include/ddsrouter_utils/time/ProportionalTimer.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/time/ProportionalTimer.hpp
@@ -1,0 +1,91 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ProportionalTimer.hpp
+ */
+
+#ifndef _DDSROUTERUTILS_TIMER_PROPORTIONAL_TIMER_HPP_
+#define _DDSROUTERUTILS_TIMER_PROPORTIONAL_TIMER_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <ddsrouter_utils/library/library_dll.h>
+#include <ddsrouter_utils/time/PausableTimer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+/**
+ * @brief Class to measure time elapsed and allow to pause and replay it.
+ *
+ * This class has 2 states, paused and playing.
+ * It stores internally the amount of time that has been elapsed while the timer is playing.
+ *
+ * @note the internal \c Timer parent class actually counts the time since the state has changed.
+ *
+ * @warning This class is not thread safe
+ */
+class ProportionalTimer : protected Timer
+{
+public:
+
+    /**
+     * @brief Create a new Timer which stores the time it has been created
+     *
+     * @param play whether the times should start playing or else paused
+     */
+    DDSROUTER_UTILS_DllAPI ProportionalTimer(bool activated) noexcept;
+
+    /**
+     * @brief Replay a paused Timer.
+     *
+     * If already playing, do nothing.
+     */
+    DDSROUTER_UTILS_DllAPI void activate() noexcept;
+
+    /**
+     * @brief Pause the timer. Time while paused does not count as elapsed.
+     *
+     * If already paused, do nothing
+     */
+    DDSROUTER_UTILS_DllAPI void deactivate() noexcept;
+
+    //! Whether the timer is playing or paused
+    DDSROUTER_UTILS_DllAPI bool active() const noexcept;
+
+    DDSROUTER_UTILS_DllAPI double elapsed() const noexcept override;
+
+    DDSROUTER_UTILS_DllAPI double elapsed_active() const noexcept;
+
+    DDSROUTER_UTILS_DllAPI double active_proportion() const noexcept;
+
+    /**
+     * @brief  Reset timer initial time to the moment \c reset is called.
+     *
+     * It also reset the internal counter value, so it starts from 0 as if it was created at this moment.
+     */
+    DDSROUTER_UTILS_DllAPI void reset() noexcept;
+
+protected:
+
+    PausableTimer active_timer_;
+};
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */
+
+#endif /* _DDSROUTERUTILS_TIMER_PROPORTIONAL_TIMER_HPP_ */

--- a/ddsrouter_utils/include/ddsrouter_utils/time/Timer.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/time/Timer.hpp
@@ -1,0 +1,69 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Timer.hpp
+ */
+
+#ifndef _DDSROUTERUTILS_TIMER_HPP_
+#define _DDSROUTERUTILS_TIMER_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <ddsrouter_utils/library/library_dll.h>
+#include <ddsrouter_utils/time/time_utils.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+/**
+ * @brief Class to measure time elapsed.
+ *
+ * When creating an object of this class stores the time \c now when it is created.
+ * Using method \c elapsed / \c elapsed_ms gives the amount of time elapsed since its creation.
+ */
+class Timer
+{
+public:
+
+    //! @brief Create a new Timer which stores the time it has been created
+    DDSROUTER_UTILS_DllAPI Timer() noexcept;
+
+    //! Reset timer initial time to the moment \c reset is called.
+    DDSROUTER_UTILS_DllAPI virtual void reset() noexcept;
+
+    //! Elapsed time in milliseconds since beggining or last reset
+    DDSROUTER_UTILS_DllAPI virtual double elapsed() const noexcept;
+
+    /**
+     * @brief Elapsed time rounded to milliseconds
+     *
+     * @note Derived method: do not need to be overriden
+     *
+     * @return number of milliseconds elapsed since beggining or last reset
+     */
+    DDSROUTER_UTILS_DllAPI Duration_ms elapsed_ms() const noexcept;
+
+protected:
+
+    //! Time when the object has been created OR when last reset has been called.
+    std::chrono::time_point<std::chrono::high_resolution_clock> start_time_;
+};
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */
+
+#endif /* _DDSROUTERUTILS_TIMER_HPP_ */

--- a/ddsrouter_utils/include/ddsrouter_utils/time/time_utils.hpp
+++ b/ddsrouter_utils/include/ddsrouter_utils/time/time_utils.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @file Timestamp.hpp
+ * @file time_utils.hpp
  */
 
 #ifndef _DDSROUTERUTILS_TIME_HPP_
@@ -47,33 +47,8 @@ DDSROUTER_UTILS_DllAPI Timestamp the_end_of_times() noexcept;
 DDSROUTER_UTILS_DllAPI std::chrono::milliseconds duration_to_ms(
         const Duration_ms& duration) noexcept;
 
-/**
- * @brief Class to measure time elapsed.
- *
- * When creating an object of this class stores the time \c now when it is created.
- * Using method \c elapsed / \c elapsed_ms gives the amount of time elapsed since its creation.
- */
-class Timer
-{
-public:
-
-    //! Create a new Timer which stores the time it has been created
-    DDSROUTER_UTILS_DllAPI Timer() noexcept;
-
-    //! Reset timer initial time to the moment \c reset is called.
-    DDSROUTER_UTILS_DllAPI void reset() noexcept;
-
-    //! Elapsed time in milliseconds
-    DDSROUTER_UTILS_DllAPI double elapsed() const noexcept;
-
-    //! Elapsed time rounded to milliseconds
-    DDSROUTER_UTILS_DllAPI Duration_ms elapsed_ms() const noexcept;
-
-protected:
-
-    //! Time when the object has been created OR when last reset has been called.
-    std::chrono::time_point<std::chrono::high_resolution_clock> start_time_;
-};
+DDSROUTER_UTILS_DllAPI void sleep_for(
+        const Duration_ms& sleep_time) noexcept;
 
 } /* namespace utils */
 } /* namespace ddsrouter */

--- a/ddsrouter_utils/src/cpp/Formatter.cpp
+++ b/ddsrouter_utils/src/cpp/Formatter.cpp
@@ -25,7 +25,12 @@ namespace utils {
 
 std::string Formatter::to_string() const noexcept
 {
-    return ss_.str().c_str();
+    return ss_.str();
+}
+
+Formatter::operator std::string() const noexcept
+{
+    return ss_.str();
 }
 
 std::ostream& operator <<(

--- a/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
+++ b/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ExecutionTimerDebugger.cpp
+ */
+
+#include <ddsrouter_utils/performance_debugger/ExecutionTimerDebugger.hpp>
+#include <ddsrouter_utils/Log.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+namespace debug {
+
+#if EPROSIMA_PERFORMANCE_DEBUG
+
+ExecutionTimerDebugger::ExecutionTimerDebugger(const std::string& debugger_name)
+    : timer_(false)
+    , debugger_name_(debugger_name)
+{
+}
+
+ExecutionTimerDebugger::~ExecutionTimerDebugger()
+{
+    double total_time = timer_.elapsed();
+    double execution_time = timer_.elapsed_active();
+    double proportion = timer_.active_proportion();
+
+    logPerformance(
+        PERFORMANCE,
+        "ExecutionTimerDebugger <" << debugger_name_ << "> has lived for " << total_time << " seconds. " <<
+        "It has worked for " << execution_time << " seconds. Thus it has worked  " <<
+        (100*proportion) << "\% of it total life time.");
+}
+
+void ExecutionTimerDebugger::in_execution()
+{
+    timer_.activate();
+}
+
+void ExecutionTimerDebugger::end_execution()
+{
+    timer_.deactivate();
+}
+
+#endif // if EPROSIMA_PERFORMANCE_DEBUG
+
+} /* namespace debug */
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */

--- a/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
+++ b/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
@@ -24,7 +24,7 @@ namespace ddsrouter {
 namespace utils {
 namespace debug {
 
-#if EPROSIMA_PERFORMANCE_DEBUG
+#ifdef EPROSIMA_PERFORMANCE_DEBUG
 
 ExecutionTimerDebugger::ExecutionTimerDebugger(const std::string& debugger_name)
     : timer_(false)

--- a/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
+++ b/ddsrouter_utils/src/cpp/performance_debugger/ExecutionTimerDebugger.cpp
@@ -40,8 +40,8 @@ ExecutionTimerDebugger::~ExecutionTimerDebugger()
 
     logPerformance(
         PERFORMANCE,
-        "ExecutionTimerDebugger <" << debugger_name_ << "> has lived for " << total_time << " seconds. " <<
-        "It has worked for " << execution_time << " seconds. Thus it has worked  " <<
+        "ExecutionTimerDebugger <" << debugger_name_ << "> has lived for " << total_time << " milliseconds. " <<
+        "It has worked for " << execution_time << " milliseconds. Thus it has worked  " <<
         (100*proportion) << "\% of it total life time.");
 }
 

--- a/ddsrouter_utils/src/cpp/time/PausableTimer.cpp
+++ b/ddsrouter_utils/src/cpp/time/PausableTimer.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Time.cpp
+ *
+ */
+
+#include <ddsrouter_utils/time/PausableTimer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+PausableTimer::PausableTimer(bool play /* = true */) noexcept
+    : playing_(play)
+    , stored_time_elapsed_(0)
+{
+}
+
+void PausableTimer::play() noexcept
+{
+    // If object was paused, reactivate the counter
+    if (!playing_.exchange(true))
+    {
+        reset_();
+    }
+
+    // If it was already playing, do nothing
+}
+
+void PausableTimer::pause() noexcept
+{
+    // If object was playing, store the amount of data elapsed and restore the counter
+    if (playing_.exchange(false))
+    {
+        stored_time_elapsed_ += Timer::elapsed();
+        reset_();
+    }
+
+    // If it was already paused, do nothing
+}
+
+// WOW! This method was written by copilot. First time I saw it doing something intellectually "complex"
+double PausableTimer::elapsed() const noexcept
+{
+    // If object is paused, return the amount of data elapsed
+    if (!playing_.load())
+    {
+        return stored_time_elapsed_;
+    }
+    else
+    {
+        // Otherwise, return the amount of data elapsed since the object was created
+        return stored_time_elapsed_ + Timer::elapsed();
+    }
+}
+
+void PausableTimer::reset() noexcept
+{
+    stored_time_elapsed_ = 0;
+    reset_();
+}
+
+bool PausableTimer::playing() const noexcept
+{
+    return playing_.load();
+}
+
+void PausableTimer::reset_() noexcept
+{
+    Timer::reset();
+}
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */

--- a/ddsrouter_utils/src/cpp/time/PausableTimer.cpp
+++ b/ddsrouter_utils/src/cpp/time/PausableTimer.cpp
@@ -23,7 +23,7 @@ namespace eprosima {
 namespace ddsrouter {
 namespace utils {
 
-PausableTimer::PausableTimer(bool play /* = true */) noexcept
+PausableTimer::PausableTimer(bool play) noexcept
     : playing_(play)
     , stored_time_elapsed_(0)
 {

--- a/ddsrouter_utils/src/cpp/time/ProportionalTimer.cpp
+++ b/ddsrouter_utils/src/cpp/time/ProportionalTimer.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ProportionalTimer.cpp
+ *
+ */
+
+#include <ddsrouter_utils/time/ProportionalTimer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+ProportionalTimer::ProportionalTimer(bool activated) noexcept
+    : active_timer_(activated)
+{
+}
+
+void ProportionalTimer::activate() noexcept
+{
+    active_timer_.play();
+}
+
+void ProportionalTimer::deactivate() noexcept
+{
+    active_timer_.pause();
+}
+
+bool ProportionalTimer::active() const noexcept
+{
+    return active_timer_.playing();
+}
+
+double ProportionalTimer::elapsed() const noexcept
+{
+    return Timer::elapsed();
+}
+
+double ProportionalTimer::elapsed_active() const noexcept
+{
+    return active_timer_.elapsed();
+}
+
+double ProportionalTimer::active_proportion() const noexcept
+{
+    double total_elapsed = elapsed();
+
+    if (total_elapsed)
+    {
+        return active_timer_.elapsed() / total_elapsed;
+    }
+    else
+    {
+        return 0.0;
+    }
+}
+
+void ProportionalTimer::reset() noexcept
+{
+    Timer::reset();
+    active_timer_.reset();
+}
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */

--- a/ddsrouter_utils/src/cpp/time/Timer.cpp
+++ b/ddsrouter_utils/src/cpp/time/Timer.cpp
@@ -1,0 +1,50 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Time.cpp
+ *
+ */
+
+#include <ddsrouter_utils/time/Timer.hpp>
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+
+Timer::Timer() noexcept
+    : start_time_(std::chrono::high_resolution_clock::now())
+{
+}
+
+void Timer::reset() noexcept
+{
+    start_time_ = std::chrono::high_resolution_clock::now();
+}
+
+double Timer::elapsed() const noexcept
+{
+    std::chrono::time_point<std::chrono::high_resolution_clock> now_time = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double, std::milli>(now_time - start_time_).count();
+}
+
+Duration_ms Timer::elapsed_ms() const noexcept
+{
+    double elapsed_time = elapsed();
+    return static_cast<Duration_ms>(elapsed_time);
+}
+
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */

--- a/ddsrouter_utils/src/cpp/time/time_utils.cpp
+++ b/ddsrouter_utils/src/cpp/time/time_utils.cpp
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 /**
- * @file Time.cpp
+ * @file time_utils.cpp
  *
  */
 
-#include <ddsrouter_utils/Time.hpp>
+#include <thread>
+
+#include <ddsrouter_utils/time/time_utils.hpp>
 
 namespace eprosima {
 namespace ddsrouter {
@@ -39,26 +41,10 @@ std::chrono::milliseconds duration_to_ms(
     return std::chrono::milliseconds(duration);
 }
 
-Timer::Timer() noexcept
-    : start_time_(std::chrono::high_resolution_clock::now())
+void sleep_for(
+        const Duration_ms& sleep_time) noexcept
 {
-}
-
-void Timer::reset() noexcept
-{
-    start_time_ = std::chrono::high_resolution_clock::now();
-}
-
-double Timer::elapsed() const noexcept
-{
-    std::chrono::time_point<std::chrono::high_resolution_clock> now_time = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration<double, std::milli>(now_time - start_time_).count();
-}
-
-Duration_ms Timer::elapsed_ms() const noexcept
-{
-    double elapsed_time = elapsed();
-    return static_cast<Duration_ms>(elapsed_time);
+    std::this_thread::sleep_for(duration_to_ms(sleep_time));
 }
 
 } /* namespace utils */

--- a/ddsrouter_utils/test/unittest/time/CMakeLists.txt
+++ b/ddsrouter_utils/test/unittest/time/CMakeLists.txt
@@ -16,7 +16,8 @@ set(TEST_NAME TimerTest)
 
 set(TEST_SOURCES
         TimerTest.cpp
-        ${PROJECT_SOURCE_DIR}/src/cpp/Time.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/time/time_utils.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/time/Timer.cpp
     )
 
 set(TEST_LIST
@@ -30,9 +31,40 @@ set(TEST_EXTRA_LIBRARIES
         fastrtps
     )
 
+############################
+# PAUSABLE TIMER TEST
+############################
+
 add_unittest_executable(
         "${TEST_NAME}"
         "${TEST_SOURCES}"
         "${TEST_LIST}"
         "${TEST_EXTRA_LIBRARIES}"
     )
+
+    set(TEST_NAME PausableTimerTest)
+
+    set(TEST_SOURCES
+            PausableTimerTest.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/time/time_utils.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/time/Timer.cpp
+            ${PROJECT_SOURCE_DIR}/src/cpp/time/PausableTimer.cpp
+        )
+
+    set(TEST_LIST
+            create
+            repeat_play_pause
+            play_and_pause
+        )
+
+    set(TEST_EXTRA_LIBRARIES
+            fastcdr
+            fastrtps
+        )
+
+    add_unittest_executable(
+            "${TEST_NAME}"
+            "${TEST_SOURCES}"
+            "${TEST_LIST}"
+            "${TEST_EXTRA_LIBRARIES}"
+        )

--- a/ddsrouter_utils/test/unittest/time/PausableTimerTest.cpp
+++ b/ddsrouter_utils/test/unittest/time/PausableTimerTest.cpp
@@ -1,0 +1,184 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <thread>
+
+#include <gtest_aux.hpp>
+#include <gtest/gtest.h>
+
+#include <ddsrouter_utils/time/PausableTimer.hpp>
+
+
+namespace eprosima {
+namespace ddsrouter {
+namespace utils {
+namespace test {
+
+constexpr const eprosima::ddsrouter::utils::Duration_ms RESIDUAL_TIME = 10;
+constexpr const eprosima::ddsrouter::utils::Duration_ms TIME_WAIT_TEST = 200;
+
+} /* namespace test */
+} /* namespace utils */
+} /* namespace ddsrouter */
+} /* namespace eprosima */
+
+
+using namespace eprosima::ddsrouter::utils;
+
+/**
+ * Create a Timer and check its values
+ *
+ * CASES:
+ * - create it playing
+ * - create it paused
+ */
+TEST(PausableTimerTest, create)
+{
+    // create it playing
+    {
+        PausableTimer timer(true);
+        ASSERT_TRUE(timer.playing());
+        sleep_for(test::RESIDUAL_TIME);
+        ASSERT_LT(0, timer.elapsed());
+    }
+
+    // create it paused
+    {
+        PausableTimer timer(false);
+        ASSERT_FALSE(timer.playing());
+        ASSERT_EQ(0, timer.elapsed());
+    }
+}
+
+/**
+ * Call repeated times to play and pause without failing
+ *
+ * CASES:
+ * - play multiple times
+ * - pause multiple times
+ * - play and pause repeated
+ */
+TEST(PausableTimerTest, repeat_play_pause)
+{
+    // play multiple times
+    {
+        PausableTimer timer(true);
+        ASSERT_TRUE(timer.playing());
+
+        timer.play();
+        ASSERT_TRUE(timer.playing());
+
+        timer.play();
+        timer.play();
+        timer.play();
+        ASSERT_TRUE(timer.playing());
+    }
+
+    // pause multiple times
+    {
+        PausableTimer timer(false);
+        ASSERT_FALSE(timer.playing());
+
+        timer.pause();
+        ASSERT_FALSE(timer.playing());
+
+        timer.pause();
+        timer.pause();
+        timer.pause();
+        ASSERT_FALSE(timer.playing());
+    }
+
+    // play and pause repeated
+    {
+        PausableTimer timer(false);
+        ASSERT_FALSE(timer.playing());
+
+        timer.play();
+        timer.play();
+        ASSERT_TRUE(timer.playing());
+
+        timer.pause();
+        ASSERT_FALSE(timer.playing());
+
+        timer.pause();
+        timer.pause();
+        ASSERT_FALSE(timer.playing());
+
+        timer.play();
+        ASSERT_TRUE(timer.playing());
+    }
+}
+
+/**
+ * Test play and pause work correctly
+ *
+ * STEPS:
+ * - Start playing for N ms
+ * - Pause for 2N ms
+ * - Check time
+ * - Play again for 2N ms
+ * - Check time
+ * - Reset while playing and wait N ms
+ * - Check time
+ * - Pause and reset while paused and wait N ms
+ * - Check time
+ */
+TEST(PausableTimerTest, play_and_pause)
+{
+    PausableTimer timer(true);
+
+    // Start playing for N ms
+    sleep_for(test::TIME_WAIT_TEST);
+
+    // Pause for 2N ms
+    timer.pause();
+    sleep_for(2 * test::TIME_WAIT_TEST);
+
+    // Check time
+    ASSERT_GE(timer.elapsed_ms(), test::TIME_WAIT_TEST);
+    ASSERT_LT(timer.elapsed_ms(), 2 * test::TIME_WAIT_TEST);
+
+    // Play again for 2N ms
+    timer.play();
+    sleep_for(2 * test::TIME_WAIT_TEST);
+
+    // Check time
+    auto time_elapsed = timer.elapsed_ms();
+    ASSERT_GE(time_elapsed, 3 * test::TIME_WAIT_TEST);
+    ASSERT_LT(time_elapsed, 4 * test::TIME_WAIT_TEST);
+
+    // Reset while playing and wait N ms
+    timer.reset();
+    sleep_for(test::TIME_WAIT_TEST);
+
+    // Check time
+    ASSERT_GE(timer.elapsed_ms(), test::TIME_WAIT_TEST);
+    ASSERT_LT(timer.elapsed_ms(), 2 * test::TIME_WAIT_TEST);
+
+    // Pause and reset while paused and wait N ms
+    timer.pause();
+    timer.reset();
+    sleep_for(test::TIME_WAIT_TEST);
+
+    // Check time
+    ASSERT_EQ(0, timer.elapsed_ms());
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/ddsrouter_utils/test/unittest/time/TimerTest.cpp
+++ b/ddsrouter_utils/test/unittest/time/TimerTest.cpp
@@ -17,7 +17,7 @@
 #include <gtest_aux.hpp>
 #include <gtest/gtest.h>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/Timer.hpp>
 
 using namespace eprosima::ddsrouter::utils;
 

--- a/tools/ddsrouter_tool/src/cpp/main.cpp
+++ b/tools/ddsrouter_tool/src/cpp/main.cpp
@@ -26,7 +26,7 @@
 #include <ddsrouter_utils/exception/ConfigurationException.hpp>
 #include <ddsrouter_utils/exception/InitializationException.hpp>
 #include <ddsrouter_utils/ReturnCode.hpp>
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 #include <ddsrouter_utils/utils.hpp>
 #include <ddsrouter_yaml/YamlReaderConfiguration.hpp>
 #include <ddsrouter_yaml/YamlManager.hpp>

--- a/tools/ddsrouter_tool/src/cpp/user_interface/arguments_configuration.hpp
+++ b/tools/ddsrouter_tool/src/cpp/user_interface/arguments_configuration.hpp
@@ -24,7 +24,7 @@
 
 #include <optionparser.h>
 
-#include <ddsrouter_utils/Time.hpp>
+#include <ddsrouter_utils/time/time_utils.hpp>
 
 #include "ProcessReturnCode.hpp"
 


### PR DESCRIPTION
After #209 

- This new class allow to measure easily the time spent inside a class or function in a way that the performance in release is not affected. [6a26624]

- Add CMake option `EPROSIMA_PERFORMANCE_DEBUG` [c6aa53d]

- Add this class to Track, so every Track measure the time it elapsed transmitting [3948aca]