### PR TITLE
Update to GTest 1.11.0 [14565]

### DIFF
--- a/ddsrouter_core/test/unittest/efficiency/PayloadPoolTest.cpp
+++ b/ddsrouter_core/test/unittest/efficiency/PayloadPoolTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <fastdds/rtps/common/CacheChange.h>
+#include <fastdds/rtps/common/SerializedPayload.h>
 
 #include <efficiency/PayloadPool.hpp>
 #include <ddsrouter_utils/exception/InconsistencyException.hpp>
@@ -30,6 +31,33 @@ using namespace eprosima::ddsrouter::core::types;
 using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/*
+ * WORKAROUND:
+ * This definition is needed due to googletest-distribution (1.11.0) requires to every class used inside ASSERT macro
+ * to have the operator << defined in SAME namespace than the class.
+ * In our case, Payload is defined as eprosima::fastrtps::rtps::SerializedPayload_t but redefined as
+ * eprosima::ddsrouter::core::types::Payload and the operator << is defined in eprosima::ddsrouter::core::types
+ * Thus, gtest could not find this definition (arising a very messy and cryptic compilation error).
+ * This definition corrects that problem.
+ *
+ * NOTE:
+ * In googletest-distribution release-1.10.0 this does not happen.
+ */
+void PrintTo(
+        const SerializedPayload_t,
+        std::ostream* os)
+{
+    *os << "::eprosima::fastrtps::rtps::SerializedPayload_t";
+}
+
+} /* namespace rtps */
+} /* namespace fastrtps */
+} /* namespace eprosima */
 
 namespace eprosima {
 namespace ddsrouter {

--- a/docs/rst/developer_manual/installation/sources/linux.rst
+++ b/docs/rst/developer_manual/installation/sources/linux.rst
@@ -100,7 +100,7 @@ Use the following command to download the code:
 
 .. code-block:: bash
 
-    git clone --branch release-1.10.0 https://github.com/google/googletest src/googletest-distribution
+    git clone --branch release-1.11.0 https://github.com/google/googletest src/googletest-distribution
 
 
 .. _py_yaml:


### PR DESCRIPTION
Add operator << in correct namespace and change gtest distribution branch

Signed-off-by: jparisu <javierparis@eprosima.com>