### PR TITLE
Set Participant and Reader listeners after having been created

### DIFF
--- a/ddsrouter_core/src/cpp/participant/implementations/rtps/impl/CommonRTPSRouterParticipant.ipp
+++ b/ddsrouter_core/src/cpp/participant/implementations/rtps/impl/CommonRTPSRouterParticipant.ipp
@@ -219,7 +219,12 @@ void CommonRTPSRouterParticipant<ConfigurationType>::create_participant_()
     logInfo(DDSROUTER_RTPS_PARTICIPANT,
             "Creating Participant in domain " << domain);
 
-    rtps_participant_ = fastrtps::rtps::RTPSDomain::createParticipant(domain(), params, this);
+    rtps_participant_ = fastrtps::rtps::RTPSDomain::createParticipant(domain(), params);
+
+    // Set listener after participant creation to avoid SEGFAULT (produced when callback using rtps_participant_ is
+    // invoked before the variable is fully set)
+    rtps_participant_->set_listener(this);
+
     if (!rtps_participant_)
     {
         throw utils::InitializationException(

--- a/ddsrouter_core/src/cpp/reader/implementations/rtps/Reader.cpp
+++ b/ddsrouter_core/src/cpp/reader/implementations/rtps/Reader.cpp
@@ -47,8 +47,11 @@ Reader::Reader(
         rtps_participant,
         reader_att,
         payload_pool_,
-        rtps_history_,
-        this);
+        rtps_history_);
+
+    // Set listener after entity creation to avoid SEGFAULT (produced when callback using rtps_reader_ is
+    // invoked before the variable is fully set)
+    rtps_reader_->setListener(this);
 
     if (!rtps_reader_)
     {


### PR DESCRIPTION
This PR fixes an infrequent segmentation fault produced when a listener callback tries to access a variable in the middle of an assignment operation.