### PR TITLE
Fix some rosdep keys

### DIFF
--- a/ddsrouter_core/package.xml
+++ b/ddsrouter_core/package.xml
@@ -23,7 +23,7 @@
 
   <doc_depend>doxygen</doc_depend>
 
-  <test_depend>googletest-distribution</test_depend>
+  <test_depend>gtest</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/ddsrouter_yaml/package.xml
+++ b/ddsrouter_yaml/package.xml
@@ -25,7 +25,7 @@
 
   <doc_depend>doxygen</doc_depend>
 
-  <test_depend>googletest-distribution</test_depend>
+  <test_depend>gtest</test_depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/ddsrouter_yaml/package.xml
+++ b/ddsrouter_yaml/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>yamlcpp</depend>
+  <depend>yaml-cpp</depend>
   <depend>fastrtps</depend>
   <depend>cpp_utils</depend>
   <depend>ddsrouter_core</depend>

--- a/docs/package.xml
+++ b/docs/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>cmake_utils</depend>
-  <depend>Sphinx</depend>
+  <depend>python3-sphinx</depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/tools/ddsrouter_tool/package.xml
+++ b/tools/ddsrouter_tool/package.xml
@@ -17,7 +17,7 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>yamlcpp</depend>
+  <depend>yaml-cpp</depend>
   <depend>fastrtps</depend>
   <depend>cpp_utils</depend>
 

--- a/tools/ddsrouter_tool/package.xml
+++ b/tools/ddsrouter_tool/package.xml
@@ -26,7 +26,7 @@
 
   <doc_depend>doxygen</doc_depend>
 
-  <test_depend>googletest-distribution</test_depend>
+  <test_depend>gtest</test_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
Fix some rosdep keys,

- `googletest-distribution` -> `gtest` : ([rosdep/base](https://github.com/ros/rosdistro/blob/7dd578389846abd7644f7b3daec0d85b07414f44/rosdep/base.yaml#L1701))
- `Sphinx` -> `python3-sphinx` : ([rosdep/python](https://github.com/ros/rosdistro/blob/7dd578389846abd7644f7b3daec0d85b07414f44/rosdep/python.yaml#L9365))
- `yamlcpp` -> `yaml-cpp` : ([rosdep/base](https://github.com/ros/rosdistro/blob/9ee2f0bf1723cb385c9f3013eb7dc57579283174/rosdep/base.yaml#L8696))