### PR TITLE
Update default router version from v3.0 to v3.1

### DIFF
--- a/ddsrouter_test/compose/test_cases/dds/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/dds/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   raw: |

--- a/ddsrouter_test/compose/test_cases/dds_rtps/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/dds_rtps/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   raw: |

--- a/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_cloud_discovery.yaml
+++ b/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_cloud_discovery.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/discovery_server/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_cloud.yaml
+++ b/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_cloud.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/forwarding_routes/repeater/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 
@@ -12,4 +12,3 @@ participants:
       - domain: ddsrouter_cloud
         port: 21666
         transport: udp
-

--- a/ddsrouter_test/compose/test_cases/repeater/ddsrouter_cloud.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater/ddsrouter_cloud.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/repeater/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/repeater/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_cloud.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_cloud.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/repeater_tcp/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_cloud.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_cloud.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 allowlist:
   - name: "*addition_service*"

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 allowlist:
   - name: "*addition_service*"

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_cloud/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_correct_target/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_correct_target/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_cloud_repeater.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_cloud_repeater.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_cloud_repeater.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_cloud_repeater.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_repeater_with_talker/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_simple/ddsrouter_1.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_simple/ddsrouter_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_simple/ddsrouter_2.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_simple/ddsrouter_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial_multiple/ddsrouter_1.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial_multiple/ddsrouter_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial_multiple/ddsrouter_2.yaml
+++ b/ddsrouter_test/compose/test_cases/rpc/ros2_services_trivial_multiple/ddsrouter_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/security/backdoor/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/security/backdoor/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/security/backdoor_dds/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/security/backdoor_dds/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/security/secure_trespassing/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/security/secure_trespassing/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_client_secure.yaml
+++ b/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_client_secure.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_non_secure.yaml
+++ b/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_non_secure.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_server_secure.yaml
+++ b/ddsrouter_test/compose/test_cases/security/secure_wan/configurations/ddsrouter_server_secure.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/ddsrouter_test/compose/test_cases/tcp/ddsrouter_cloud.yaml
+++ b/ddsrouter_test/compose/test_cases/tcp/ddsrouter_cloud.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/tcp/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/tcp/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/tcp/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/tcp/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/transparency/durability/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/transparency/durability/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/transparency/ownership/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/transparency/ownership/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/transparency/partitions/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/transparency/partitions/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/udp/ddsrouter_cloud_1.yaml
+++ b/ddsrouter_test/compose/test_cases/udp/ddsrouter_cloud_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/udp/ddsrouter_cloud_2.yaml
+++ b/ddsrouter_test/compose/test_cases/udp/ddsrouter_cloud_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/udp/ddsrouter_edge_1.yaml
+++ b/ddsrouter_test/compose/test_cases/udp/ddsrouter_edge_1.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_test/compose/test_cases/udp/ddsrouter_edge_2.yaml
+++ b/ddsrouter_test/compose/test_cases/udp/ddsrouter_edge_2.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/ddsrouter_yaml/test/unittest/configuration/YamlGetConfigurationDdsRouterTest.cpp
+++ b/ddsrouter_yaml/test/unittest/configuration/YamlGetConfigurationDdsRouterTest.cpp
@@ -39,7 +39,7 @@ TEST(YamlGetConfigurationDdsRouterTest, get_ddsrouter_configuration_trivial)
 {
     const char* yml_str =
             R"(
-            version: v3.0
+            version: v3.1
             participants:
               - name: "P1"
                 kind: "echo"
@@ -84,7 +84,7 @@ TEST(YamlGetConfigurationDdsRouterTest, get_ddsrouter_configuration_ros_case)
 {
     const char* yml_str =
             R"(
-            version: v3.0
+            version: v3.1
             builtin-topics:
               - name: "rt/chatter"
                 type: "std_msgs::msg::dds_::String_"

--- a/ddsrouter_yaml/test/unittest/configuration/YamlReaderConfigurationTest.cpp
+++ b/ddsrouter_yaml/test/unittest/configuration/YamlReaderConfigurationTest.cpp
@@ -200,7 +200,7 @@ TEST(YamlReaderConfigurationTest, number_of_threads)
     const char* yml_configuration =
             // trivial configuration
             R"(
-        version: v3.0
+        version: v3.1
         participants:
           - name: "P1"
             kind: "echo"
@@ -237,7 +237,7 @@ TEST(YamlReaderConfigurationTest, max_history_depth)
     const char* yml_configuration =
             // trivial configuration
             R"(
-        version: v3.0
+        version: v3.1
         participants:
           - name: "P1"
             kind: "echo"

--- a/docs/resources/getting_started/client-ddsrouter.yaml
+++ b/docs/resources/getting_started/client-ddsrouter.yaml
@@ -1,6 +1,6 @@
 # client-ddsrouter.yaml
 
-version: v3.0
+version: v3.1
 
 allowlist:
   - name: Square

--- a/docs/resources/getting_started/server-ddsrouter.yaml
+++ b/docs/resources/getting_started/server-ddsrouter.yaml
@@ -1,6 +1,6 @@
 # server-ddsrouter.yaml
 
-version: v3.0
+version: v3.1
 
 allowlist:
   - name: Square

--- a/docs/resources/use_cases/ros_cloud/ConfigMap.yaml
+++ b/docs/resources/use_cases/ros_cloud/ConfigMap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ddsrouter-config
 data:
   ddsrouter.config.file: |-
-    version: v3.0
+    version: v3.1
 
     allowlist:
       - name: rt/chatter

--- a/docs/resources/use_cases/ros_cloud/local-ddsrouter.yaml
+++ b/docs/resources/use_cases/ros_cloud/local-ddsrouter.yaml
@@ -1,6 +1,6 @@
 # local-ddsrouter.yaml
 
-version: v3.0
+version: v3.1
 
 allowlist:
   - name: rt/chatter

--- a/docs/resources/use_cases/wan_tcp/dds_router_net_A.yaml
+++ b/docs/resources/use_cases/wan_tcp/dds_router_net_A.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/docs/resources/use_cases/wan_tcp/dds_router_net_B_lan.yaml
+++ b/docs/resources/use_cases/wan_tcp/dds_router_net_B_lan.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/docs/resources/use_cases/wan_tcp/dds_router_net_B_wan.yaml
+++ b/docs/resources/use_cases/wan_tcp/dds_router_net_B_wan.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 participants:
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -36,16 +36,16 @@ with future releases.
         - ``v2.0``
         - *v0.2.0*
 
-    *   - version 3.0 (default)
-        - ``v3.0``
-        - *v0.3.0*
+    *   - version 3.1 (default)
+        - ``v3.1``
+        - *v0.3.1*
 
-**Current configuration version is v3.0**.
+**Current configuration version is v3.1**.
 This is the configuration version that is described along this page.
 
 .. note::
 
-    The current default version when the tag ``version`` is not set is *v3.0*.
+    The current default version when the tag ``version`` is not set is *v3.1*.
 
 .. warning::
 
@@ -55,7 +55,7 @@ This is the configuration version that is described along this page.
 .. warning::
 
     **Deprecation warning**.
-    Update to  version `v3.0` since `v1.0` is no longer supported.
+    Update to  version `v3.1` since `v1.0` is no longer supported.
 
 
 .. _thread_configuration:
@@ -102,7 +102,7 @@ Load XML Configuration
 Fast DDS supports configuration of its internal entities (:term:`DomainParticipant`, :term:`DataWriter`, etc.) via XML Profiles.
 These XML files contain different profiles that set specific QoS, and entities can be created following such profiles.
 These XML files can be loaded in the process by their *default file name* or by an environment variable.
-Check the `Fast DDS documentation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/xml_configuration.html>` for more information.
+Check the `Fast DDS documentation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/xml_configuration.html>`_ for more information.
 
 Another way of loading these XML configurations is using the |ddsrouter| yaml configuration.
 The YAML Configuration supports a ``xml`` **optional** tag that contains certain options to load Fast DDS XML configurations.
@@ -773,7 +773,7 @@ A complete example of all the configurations described on this page can be found
 .. code-block:: yaml
 
     # Version Latest
-    version: v3.0
+    version: v3.1
 
     # Specifications
     specs:

--- a/resources/configurations/examples/change_domain.yaml
+++ b/resources/configurations/examples/change_domain.yaml
@@ -3,7 +3,7 @@
 #############################
 
 # Yaml configuration file version
-version: v3.0
+version: v3.1
 
 # DDS Router participants
 participants:

--- a/resources/configurations/examples/change_domain_allowlist.yaml
+++ b/resources/configurations/examples/change_domain_allowlist.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                               # 0
+version: v3.1                                                               # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/echo.yaml
+++ b/resources/configurations/examples/echo.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                         # 0
+version: v3.1                                                         # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/repeater.yaml
+++ b/resources/configurations/examples/repeater.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/ros_discovery_client.yaml
+++ b/resources/configurations/examples/ros_discovery_client.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/ros_discovery_server.yaml
+++ b/resources/configurations/examples/ros_discovery_server.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                      # 0
+version: v3.1                                      # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/wan_client.yaml
+++ b/resources/configurations/examples/wan_client.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/wan_ds_client.yaml
+++ b/resources/configurations/examples/wan_ds_client.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/wan_ds_server.yaml
+++ b/resources/configurations/examples/wan_ds_server.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/wan_server.yaml
+++ b/resources/configurations/examples/wan_server.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # ALLOWED TOPICS

--- a/resources/configurations/examples/xml.yaml
+++ b/resources/configurations/examples/xml.yaml
@@ -4,7 +4,7 @@
 
 ##################################
 # CONFIGURATION VERSION
-version: v3.0                                                     # 0
+version: v3.1                                                     # 0
 
 ##################################
 # CONFIGURATION VERSION

--- a/resources/configurations/security/dds/configurations/ddsrouter.yaml
+++ b/resources/configurations/security/dds/configurations/ddsrouter.yaml
@@ -1,4 +1,4 @@
-version: v3.0
+version: v3.1
 
 xml:
   files:

--- a/tools/ddsrouter_tool/test/application/configurations/complex_configuration_v3.yaml
+++ b/tools/ddsrouter_tool/test/application/configurations/complex_configuration_v3.yaml
@@ -6,7 +6,7 @@
 # 1 Initial Peers repeater Participant with connection and listening addresses
 # 2 topics, one with key and one without
 
-version: v3.0
+version: v3.1
 
 builtin-topics:
   - name: "rt/chatter"

--- a/tools/ddsrouter_tool/test/application/configurations/wan_configuration.yaml
+++ b/tools/ddsrouter_tool/test/application/configurations/wan_configuration.yaml
@@ -1,5 +1,5 @@
 
-version: v3.0
+version: v3.1
 
 participants:
 


### PR DESCRIPTION
- Update the configuration section that specifies the default version.
- Update the DDS Router yamls to specify version: v3.1.
- Fix dead links in the XML Participant configuration section.

Merge after:
- https://github.com/eProsima/DDS-Router/pull/387
- https://github.com/eProsima/DDS-Router/pull/398