### PR TITLE
Max-reception-rate & down-sampling tags

### DIFF
--- a/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
+++ b/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
@@ -61,6 +61,20 @@ struct SpecsConfiguration : public ddspipe::core::IConfiguration
      * @note Default value is 5000 as in Fast DDS.
      */
     ddspipe::core::types::HistoryDepthType max_history_depth = 5000;
+
+    /**
+     * @brief Downsampling value by default in those topics where it is not specified.
+     *
+     * @note Default value is 1 as in Fast DDS.
+     */
+    unsigned int downsampling = 1;
+
+    /**
+     * @brief Maximum Reception Rate by default in those topics where it is not specified.
+     *
+     * @note Default value is 0 as in Fast DDS.
+     */
+    float max_reception_rate = 0;
 };
 
 } /* namespace core */

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -51,6 +51,24 @@ void YamlReader::fill(
     {
         object.max_history_depth = YamlReader::get<unsigned int>(yml, MAX_HISTORY_DEPTH_TAG, version);
     }
+
+    /////
+    // Get optional downsampling
+    if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
+    {
+        auto downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
+        // Set default value for downsampling
+        ddspipe::core::types::TopicQoS::default_downsampling.store(downsampling);
+    }
+
+    /////
+    // Get optional max reception rate
+    if (YamlReader::is_tag_present(yml, MAX_RECEPTION_RATE_TAG))
+    {
+        // Set default value for max reception rate
+        ddspipe::core::types::TopicQoS::default_max_reception_rate.store(YamlReader::get_nonnegative_float(yml,
+                MAX_RECEPTION_RATE_TAG));
+    }
 }
 
 template <>

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -57,6 +57,10 @@ void YamlReader::fill(
     if (YamlReader::is_tag_present(yml, DOWNSAMPLING_TAG))
     {
         auto downsampling = YamlReader::get_positive_int(yml, DOWNSAMPLING_TAG);
+
+        // Save the downsampling value in the advanced options
+        object.downsampling = downsampling;
+
         // Set default value for downsampling
         ddspipe::core::types::TopicQoS::default_downsampling.store(downsampling);
     }
@@ -65,9 +69,13 @@ void YamlReader::fill(
     // Get optional max reception rate
     if (YamlReader::is_tag_present(yml, MAX_RECEPTION_RATE_TAG))
     {
+        auto max_reception_rate = YamlReader::get_nonnegative_float(yml, MAX_RECEPTION_RATE_TAG);
+
+        // Save the max reception rate value in the advanced options
+        object.max_reception_rate = max_reception_rate;
+
         // Set default value for max reception rate
-        ddspipe::core::types::TopicQoS::default_max_reception_rate.store(YamlReader::get_nonnegative_float(yml,
-                MAX_RECEPTION_RATE_TAG));
+        ddspipe::core::types::TopicQoS::default_max_reception_rate.store(max_reception_rate);
     }
 }
 

--- a/ddsrouter_yaml/test/unittest/configuration/CMakeLists.txt
+++ b/ddsrouter_yaml/test/unittest/configuration/CMakeLists.txt
@@ -31,6 +31,8 @@ set(TEST_LIST
         version_negative_cases
         number_of_threads
         max_history_depth
+        max_reception_rate
+        downsampling
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/ddsrouter_yaml/test/unittest/configuration/YamlReaderConfigurationTest.cpp
+++ b/ddsrouter_yaml/test/unittest/configuration/YamlReaderConfigurationTest.cpp
@@ -263,6 +263,80 @@ TEST(YamlReaderConfigurationTest, max_history_depth)
     }
 }
 
+/**
+ * Test load of max reception rate in the configuration
+ *
+ * CASES:
+ * - trivial configuration
+ */
+TEST(YamlReaderConfigurationTest, max_reception_rate)
+{
+    const char* yml_configuration =
+            // trivial configuration
+            R"(
+        version: v3.0
+        participants:
+          - name: "P1"
+            kind: "echo"
+          - name: "P2"
+            kind: "echo"
+        )";
+    Yaml yml = YAML::Load(yml_configuration);
+
+    std::vector<unsigned int> test_cases = {0, 10, 100, 1000, 5000, 10000};
+
+    for (unsigned int test_case : test_cases)
+    {
+        Yaml yml_specs;
+        yml_specs[ddspipe::yaml::MAX_RECEPTION_RATE_TAG] = test_case;
+        yml[ddspipe::yaml::SPECS_TAG] = yml_specs;
+
+        // Load configuration
+        ddsrouter::core::DdsRouterConfiguration configuration_result =
+                ddsrouter::yaml::YamlReaderConfiguration::load_ddsrouter_configuration(yml);
+
+        // Check max history depth is correct
+        ASSERT_EQ(test_case, configuration_result.advanced_options.max_reception_rate);
+    }
+}
+
+/**
+ * Test load of max reception rate in the configuration
+ *
+ * CASES:
+ * - trivial configuration
+ */
+TEST(YamlReaderConfigurationTest, downsampling)
+{
+    const char* yml_configuration =
+            // trivial configuration
+            R"(
+        version: v3.0
+        participants:
+          - name: "P1"
+            kind: "echo"
+          - name: "P2"
+            kind: "echo"
+        )";
+    Yaml yml = YAML::Load(yml_configuration);
+
+    std::vector<unsigned int> test_cases = {1, 10, 100, 1000, 5000, 10000};
+
+    for (unsigned int test_case : test_cases)
+    {
+        Yaml yml_specs;
+        yml_specs[ddspipe::yaml::DOWNSAMPLING_TAG] = test_case;
+        yml[ddspipe::yaml::SPECS_TAG] = yml_specs;
+
+        // Load configuration
+        ddsrouter::core::DdsRouterConfiguration configuration_result =
+                ddsrouter::yaml::YamlReaderConfiguration::load_ddsrouter_configuration(yml);
+
+        // Check max history depth is correct
+        ASSERT_EQ(test_case, configuration_result.advanced_options.downsampling);
+    }
+}
+
 int main(
         int argc,
         char** argv)

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -9,6 +9,8 @@ Forthcoming Version
 The next release will include the following **Features**:
 
 * :ref:`Forwarding Routes <user_manual_configuration_forwarding_routes>`.
+* :ref:`Max Reception Rate <user_manual_configuration_max_reception_rate>`.
+* :ref:`Downsampling <user_manual_configuration_downsampling>`.
 
 The next release will include the following **Bugfixes**:
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -93,6 +93,28 @@ topics and |ddsrouter| participants) are as big as to cause memory exhaustion is
 Likewise, one may choose to increase this value if wishing to deliver a greater number of samples to late joiners and
 enough memory is available.
 
+Max Reception Rate
+------------------
+
+The ``max-reception-rate`` tag limits the frequency [Hz] at which samples are processed by discarding messages received before :code:`1/max-reception-rate` seconds have passed since the last processed message.
+It only accepts non-negative numbers.
+By default it is set to ``0``; it processes samples at an unlimited reception rate.
+
+.. note::
+
+    The ``max-reception-rate`` tag can be set (in order of precedence) for built-in topics, for participants, and globally in specs.
+
+Downsampling
+------------
+
+The ``downsampling`` tag reduces the sampling rate of the received data by only keeping *1* out of every *n* samples received (per topic), where *n* is the value specified under the ``downsampling`` tag.
+When the ``max-reception-rate`` tag is also set, downsampling only applies to messages that have passed the ``max-reception-rate`` filter.
+It only accepts positive integers.
+By default it is set to ``1``; it accepts every message.
+
+.. note::
+
+    The ``downsampling`` tag can be set (in order of precedence) for built-in topics, for participants, and globally in specs.
 
 .. _user_manual_configuration_load_xml:
 
@@ -205,8 +227,20 @@ Apart from these values, the tag ``qos`` under each topic allows to configure th
         - ``false``
         - Topic with / without key
 
-The entry ``keyed`` determines whether the corresponding topic is `keyed <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/topic/typeSupport/typeSupport.html#data-types-with-a-key>`_
-or not. See the :term:`Topic` section for further information about the topic.
+    *   - Downsampling
+        - ``downsampling``
+        - *integer*
+        - *default value*
+        - Downsampling factor
+
+    *   - Max Reception Rate
+        - ``max-reception-rate``
+        - *float*
+        - *default value*
+        - Maximum sample reception rate [Hz]
+
+The entry ``keyed`` determines whether the corresponding topic is `keyed <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/topic/typeSupport/typeSupport.html#data-types-with-a-key>`_ or not.
+See the :term:`Topic` section for further information about the topic.
 
 
 .. code-block:: yaml
@@ -779,6 +813,8 @@ A complete example of all the configurations described on this page can be found
     specs:
       threads: 10
       max-depth: 1000
+      downsampling: 3
+      max-reception-rate: 20
 
     # XML configurations to load
     xml:
@@ -810,6 +846,8 @@ A complete example of all the configurations described on this page can be found
         qos:
           reliability: true
           durability: true
+          max-reception-rate: 10
+          downsampling: 4
 
     # Do not allow ROS2 services
 
@@ -830,6 +868,8 @@ A complete example of all the configurations described on this page can be found
 
         domain: 3                       # DomainId = 3
 
+        downsampling: 1                 # Downsampling = 1
+
     ####################
 
     # Simple DDS Participant in domain 7
@@ -839,6 +879,8 @@ A complete example of all the configurations described on this page can be found
         kind: local                     # Participant Kind = local (= simple)
 
         domain: 7                       # DomainId = 7
+
+        max-reception-rate: 15          # Max Reception Rate = 15
 
     ####################
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -93,6 +93,8 @@ topics and |ddsrouter| participants) are as big as to cause memory exhaustion is
 Likewise, one may choose to increase this value if wishing to deliver a greater number of samples to late joiners and
 enough memory is available.
 
+.. _user_manual_configuration_max_reception_rate:
+
 Max Reception Rate
 ------------------
 
@@ -103,6 +105,8 @@ By default it is set to ``0``; it processes samples at an unlimited reception ra
 .. note::
 
     The ``max-reception-rate`` tag can be set (in order of precedence) for built-in topics, for participants, and globally in specs.
+
+.. _user_manual_configuration_downsampling:
 
 Downsampling
 ------------


### PR DESCRIPTION
Parse the max-reception-rate & down-sampling tags from the YAML and send them to the DDS Pipe.

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/63