### PR TITLE
 Create all tracks on built-in topics

### DIFF
--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -18,6 +18,10 @@ The next release will include the following **Features**:
 * Rename the `max-depth` under the `specs` tag to `history-depth`.
 * Set `app_id` and `app_metadata` attributes in *eProsima DDS Router* participants.
 
+The next release will include the following **Fixes**:
+
+* Make :ref:`Remove Unused Entities <user_manual_configuration_remove_unused_entities>` compatible with :ref:`Built-in Topics <user_manual_configuration_builtin_topics>`.
+
 The next release will include the following **Bugfixes**:
 
 * Save the instance handle data for keyed topics.

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -336,6 +336,9 @@ By setting the ``remove-unused-entities`` option to ``true``, the internal entit
 .. warning::
   At the time being, ``remove-unused-entities: true`` is only compatible with a :ref:`discovery-trigger <user_manual_configuration_discovery_trigger>` set to ``reader``.
 
+.. note::
+  The ``remove-unused-entities`` option doesn't apply to :ref:`Built-in Topics <user_manual_configuration_builtin_topics>` since they are created before they are discovered by a :term:`Participant`.
+
 .. _user_manual_configuration_discovery_trigger:
 
 Discovery Trigger

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -337,7 +337,7 @@ By setting the ``remove-unused-entities`` option to ``true``, the internal entit
   At the time being, ``remove-unused-entities: true`` is only compatible with a :ref:`discovery-trigger <user_manual_configuration_discovery_trigger>` set to ``reader``.
 
 .. note::
-  The ``remove-unused-entities`` option doesn't apply to :ref:`Built-in Topics <user_manual_configuration_builtin_topics>` since they are created before they are discovered by a :term:`Participant`.
+  The ``remove-unused-entities`` option doesn't apply to :ref:`Built-in Topics <user_manual_configuration_builtin_topics>` since they are created before being discovered by a :term:`Participant`.
 
 .. _user_manual_configuration_discovery_trigger:
 


### PR DESCRIPTION
In the previous version, built-in topics were incompatible with `remove-unused-entities`. Now, `remove-unused-entities` only applies to topics that are discovered (i.e. topics that aren't built-in). 

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/79