### PR TITLE
Don't check subscribers' max-time when verifying the max-tx-rate in tests

### DIFF
--- a/ddsrouter_test/compose/test_cases/frequency/downsampling/participant/compose.yml
+++ b/ddsrouter_test/compose/test_cases/frequency/downsampling/participant/compose.yml
@@ -59,7 +59,7 @@ services:
       - std_net
     volumes:
       - ../../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 82 --topic topic_0"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 82 --topic topic_0"
 
   # DOMAIN 3
   subscriber_3_t1:

--- a/ddsrouter_test/compose/test_cases/frequency/downsampling/specs/compose.yml
+++ b/ddsrouter_test/compose/test_cases/frequency/downsampling/specs/compose.yml
@@ -67,7 +67,7 @@ services:
       - std_net
     volumes:
       - ../../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 83 --topic topic_1"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 83 --topic topic_1"
 
 networks:
   std_net:

--- a/ddsrouter_test/compose/test_cases/frequency/max-rx-rate/participant/compose.yml
+++ b/ddsrouter_test/compose/test_cases/frequency/max-rx-rate/participant/compose.yml
@@ -67,7 +67,7 @@ services:
       - std_net
     volumes:
       - ../../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 83 --topic topic_1"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 83 --topic topic_1"
 
 networks:
   std_net:

--- a/ddsrouter_test/compose/test_cases/frequency/max-tx-rate/participant/compose.yml
+++ b/ddsrouter_test/compose/test_cases/frequency/max-tx-rate/participant/compose.yml
@@ -45,7 +45,7 @@ services:
       - std_net
     volumes:
       - ../../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 81 --topic topic_0"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 81 --topic topic_0"
 
   # DOMAIN 2
   subscriber_2:

--- a/ddsrouter_test/compose/test_cases/manual_topics/participants/compose.yml
+++ b/ddsrouter_test/compose/test_cases/manual_topics/participants/compose.yml
@@ -76,7 +76,7 @@ services:
       - std_net
     volumes:
       - ../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 81 --topic topic_1"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 81 --topic topic_1"
 
   # DOMAIN 2
   subscriber_2_t0:
@@ -86,7 +86,7 @@ services:
       - std_net
     volumes:
       - ../../../scripts:/scripts
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --max-time 4 --args "--samples 20 --domain 82 --topic topic_0"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe install/AdvancedConfigurationExample/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationExample --samples 20 --timeout 8 --min-time 2 --args "--samples 20 --domain 82 --topic topic_0"
 
   subscriber_2_t1:
     image: ${DDSROUTER_COMPOSE_TEST_DOCKER_IMAGE}


### PR DESCRIPTION
In the previous version, the manual topics's tests configured participants with different max-tx-rates and then verified that the subscribers didn't take less than `--min-time` (ensuring that the publication frequency got capped) or more than `--max-time`. At times, however, the publisher would take too long to match the DDS Router and the `--max-time` would be missed. Ideally, we would measure the time when the subscriber received the first message, but since the subscriber runs in a subprocess and its output is only processed when the subscriber exits, we can't. Therefore, to fix the error, we will bypass the verification of `--max-time` as it is irrelevant when only configuring the max-tx-rate.