### PR TITLE
Change validation scripts for new advanced conf example

### DIFF
--- a/ddsrouter_test/compose/scripts/execute_and_validate_publisher.py
+++ b/ddsrouter_test/compose/scripts/execute_and_validate_publisher.py
@@ -182,7 +182,7 @@ if __name__ == '__main__':
         parse_output_function=_publisher_parse_output,
         validate_output_function=validate_func,
         parse_retcode_function=_publisher_get_retcode_validate(),
-        timeout_as_error=False)
+        timeout_as_error=True)
 
     log.logger.info(f'Publisher validator exited with code {ret_code}')
 

--- a/ddsrouter_test/compose/scripts/validation.py
+++ b/ddsrouter_test/compose/scripts/validation.py
@@ -133,8 +133,9 @@ def run_command(
 
     else:
         if not timeout_as_error:
-            log.logger.error('Command finished before expected.')
-            ret_code = ReturnCode.COMMAND_FAIL
+            # A timeout is expected when timing out is not an error
+            log.logger.error('A timeout is expected. Command finished before it.')
+            ret_code = ReturnCode.FINISHED_TOO_QUICKLY
 
         # Wait a minimum elapsed time to the signal to be received
         time.sleep(0.2)

--- a/ddsrouter_test/compose/test_cases/forwarding_routes/topic_routes/ddsrouter.yaml
+++ b/ddsrouter_test/compose/test_cases/forwarding_routes/topic_routes/ddsrouter.yaml
@@ -25,7 +25,7 @@ routes:
 
 topic-routes:
   - name: topic1
-    type: HelloWorld
+    type: AdvancedConfiguration
     routes:
       - src: Local_80
         dst:


### PR DESCRIPTION
The pr https://github.com/eProsima/Fast-DDS/pull/4233 changes the string sent in the message. This pr changes the validation scripts to make it compatible with the new version of advanced configuration example.
It also changes the default value of the variable `timeout_as_error` in the publisher validation script because more appropriate.