### PR TITLE
[19983] Publish Fast-DDS's Logs

### DIFF
--- a/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
+++ b/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
@@ -18,9 +18,9 @@
 #include <set>
 
 #include <cpp_utils/Formatter.hpp>
-#include <cpp_utils/logging/LogConfiguration.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
+#include <ddspipe_core/configuration/DdsPipeLogConfiguration.hpp>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 
@@ -72,8 +72,8 @@ struct SpecsConfiguration : public ddspipe::core::IConfiguration
     //! The type of the entities whose discovery triggers the discovery callbacks.
     ddspipe::core::DiscoveryTrigger discovery_trigger = ddspipe::core::DiscoveryTrigger::READER;
 
-    //! Configuration of the CustomStdLogConsumer.
-    utils::LogConfiguration log_configuration;
+    //! Configuration of the DdsLogConsumer.
+    ddspipe::core::DdsPipeLogConfiguration log_configuration;
 };
 
 } /* namespace core */

--- a/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
+++ b/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
@@ -20,7 +20,7 @@
 #include <cpp_utils/Formatter.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
-#include <ddspipe_core/configuration/DdsLogConfiguration.hpp>
+#include <ddspipe_core/configuration/DdsPipeLogConfiguration.hpp>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 
@@ -72,8 +72,8 @@ struct SpecsConfiguration : public ddspipe::core::IConfiguration
     //! The type of the entities whose discovery triggers the discovery callbacks.
     ddspipe::core::DiscoveryTrigger discovery_trigger = ddspipe::core::DiscoveryTrigger::READER;
 
-    //! Configuration of the DdsLogConsumer.
-    ddspipe::core::DdsLogConfiguration log_configuration;
+    //! Configuration of the StdLogConsumer and the DdsLogConsumer.
+    ddspipe::core::DdsPipeLogConfiguration log_configuration;
 };
 
 } /* namespace core */

--- a/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
+++ b/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
@@ -72,7 +72,7 @@ struct SpecsConfiguration : public ddspipe::core::IConfiguration
     //! The type of the entities whose discovery triggers the discovery callbacks.
     ddspipe::core::DiscoveryTrigger discovery_trigger = ddspipe::core::DiscoveryTrigger::READER;
 
-    //! Configuration of the StdLogConsumer and the DdsLogConsumer.
+    //! Configuration of the DDS Pipe's Log consumers.
     ddspipe::core::DdsPipeLogConfiguration log_configuration;
 };
 

--- a/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
+++ b/ddsrouter_core/include/ddsrouter_core/configuration/SpecsConfiguration.hpp
@@ -20,7 +20,7 @@
 #include <cpp_utils/Formatter.hpp>
 
 #include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
-#include <ddspipe_core/configuration/DdsPipeLogConfiguration.hpp>
+#include <ddspipe_core/configuration/DdsLogConfiguration.hpp>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 
@@ -73,7 +73,7 @@ struct SpecsConfiguration : public ddspipe::core::IConfiguration
     ddspipe::core::DiscoveryTrigger discovery_trigger = ddspipe::core::DiscoveryTrigger::READER;
 
     //! Configuration of the DdsLogConsumer.
-    ddspipe::core::DdsPipeLogConfiguration log_configuration;
+    ddspipe::core::DdsLogConfiguration log_configuration;
 };
 
 } /* namespace core */

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -82,7 +82,7 @@ void YamlReader::fill(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        object.log_configuration = YamlReader::get<ddspipe::core::DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
+        object.log_configuration = YamlReader::get<ddspipe::core::DdsLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
     }
 }
 

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -82,7 +82,7 @@ void YamlReader::fill(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        object.log_configuration = YamlReader::get<ddspipe::core::DdsLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
+        object.log_configuration = YamlReader::get<ddspipe::core::DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
     }
 }
 

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -82,7 +82,8 @@ void YamlReader::fill(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        object.log_configuration = YamlReader::get<ddspipe::core::DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
+        object.log_configuration = YamlReader::get<ddspipe::core::DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG,
+                        version);
     }
 }
 

--- a/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
+++ b/ddsrouter_yaml/src/cpp/YamlReader_configuration.cpp
@@ -82,7 +82,7 @@ void YamlReader::fill(
     // Get optional Log Configuration
     if (YamlReader::is_tag_present(yml, LOG_CONFIGURATION_TAG))
     {
-        object.log_configuration = YamlReader::get<utils::LogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
+        object.log_configuration = YamlReader::get<ddspipe::core::DdsPipeLogConfiguration>(yml, LOG_CONFIGURATION_TAG, version);
     }
 }
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -444,6 +444,54 @@ By default, the filter allows all errors to be displayed, while selectively perm
 
     For the logs to function properly, the ``-DLOG_INFO=ON`` compilation flag is required.
 
+By default, the logs will be printed in the standard output.
+To publish the logs, under the tag ``publish``, set ``enable: true`` and set a ``domain`` and a ``topic-name``.
+The type of the logs published is defined as follows:
+
+**LogEntry.idl**
+
+.. code-block:: idl
+
+    const long UNDEFINED = 0x10000000;
+    const long SAMPLE_LOST = 0x10000001;
+    const long TOPIC_MISMATCH_TYPE = 0x10000002;
+    const long TOPIC_MISMATCH_QOS = 0x10000003;
+
+    enum Kind {
+      Info,
+      Warning,
+      Error
+    };
+
+    struct LogEntry {
+      @key long event;
+      Kind kind;
+      string category;
+      string message;
+      string timestamp;
+    };
+
+.. note::
+
+    The type of the logs can be published by setting ``publish-type: true``.
+
+**Example of usage**
+
+.. code-block:: yaml
+
+    logging:
+      verbosity: info
+      filter:
+        error: "DDSPIPE|DDSROUTER"
+        warning: "DDSPIPE|DDSROUTER"
+        info: "DDSROUTER"
+      publish:
+        enable: true
+        domain: 84
+        topic-name: "DdsRouterLogs"
+        publish-type: false
+      stdout: true
+
 Participant Configuration
 =========================
 
@@ -879,17 +927,25 @@ A complete example of all the configurations described on this page can be found
       threads: 10
       remove-unused-entities: false
       discovery-trigger: reader
+
       qos:
         history-depth: 1000
         max-tx-rate: 0
         max-rx-rate: 20
         downsampling: 3
+
       logging:
         verbosity: info
         filter:
           error: "DDSPIPE|DDSROUTER"
           warning: "DDSPIPE|DDSROUTER"
           info: "DDSROUTER"
+        publish:
+            enable: true
+            domain: 84
+            topic-name: "DdsRouterLogs"
+            publish-type: false
+        stdout: true
 
     # XML configurations to load
     xml:

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -444,7 +444,8 @@ By default, the filter allows all errors to be displayed, while selectively perm
 
     For the logs to function properly, the ``-DLOG_INFO=ON`` compilation flag is required.
 
-By default, the logs will be printed in the standard output.
+The |ddsrouter| prints the logs by default (warnings and errors in the standard error and infos in the standard output).
+The |ddsrouter|, however, can also publish the logs in a DDS topic.
 To publish the logs, under the tag ``publish``, set ``enable: true`` and set a ``domain`` and a ``topic-name``.
 The type of the logs published is defined as follows:
 

--- a/tools/ddsrouter_tool/src/cpp/main.cpp
+++ b/tools/ddsrouter_tool/src/cpp/main.cpp
@@ -279,5 +279,8 @@ int main(
     // Force print every log before closing
     eprosima::utils::Log::Flush();
 
+    // Delete the consumers before closing
+    eprosima::utils::Log::ClearConsumers();
+
     return static_cast<int>(ui::ProcessReturnCode::success);
 }

--- a/tools/ddsrouter_tool/src/cpp/main.cpp
+++ b/tools/ddsrouter_tool/src/cpp/main.cpp
@@ -24,7 +24,6 @@
 #include <cpp_utils/exception/ConfigurationException.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/logging/StdLogConsumer.hpp>
-#include <cpp_utils/logging/LogConfiguration.hpp>
 #include <cpp_utils/ReturnCode.hpp>
 #include <cpp_utils/time/time_utils.hpp>
 #include <cpp_utils/utils.hpp>
@@ -127,13 +126,13 @@ int main(
 
         // Debug
         {
+            const auto log_configuration = router_configuration.ddspipe_configuration.log_configuration;
+
             // Remove every consumer
             eprosima::utils::Log::ClearConsumers();
 
             // Activate log with verbosity, as this will avoid running log thread with not desired kind
-            eprosima::utils::Log::SetVerbosity(router_configuration.ddspipe_configuration.log_configuration.verbosity);
-
-            const auto log_configuration = router_configuration.ddspipe_configuration.log_configuration;
+            eprosima::utils::Log::SetVerbosity(log_configuration.verbosity);
 
             // Stdout Log Consumer
             if (log_configuration.stdout_enable)
@@ -146,7 +145,7 @@ int main(
             if (log_configuration.publish.enable)
             {
                 eprosima::utils::Log::RegisterConsumer(
-                    std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(log_configuration));
+                    std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(&log_configuration));
             }
 
             // NOTE:

--- a/tools/ddsrouter_tool/src/cpp/main.cpp
+++ b/tools/ddsrouter_tool/src/cpp/main.cpp
@@ -29,6 +29,8 @@
 #include <cpp_utils/time/time_utils.hpp>
 #include <cpp_utils/utils.hpp>
 
+#include <ddspipe_core/logging/DdsLogConsumer.hpp>
+
 #include <ddspipe_participants/xml/XmlHandler.hpp>
 
 #include <ddsrouter_core/configuration/DdsRouterConfiguration.hpp>
@@ -90,7 +92,6 @@ int main(
 
     logUser(DDSROUTER_EXECUTION, "Starting DDS Router Tool execution.");
 
-
     // Encapsulating execution in block to erase all memory correctly before closing process
     try
     {
@@ -132,9 +133,13 @@ int main(
             // Activate log with verbosity, as this will avoid running log thread with not desired kind
             eprosima::utils::Log::SetVerbosity(router_configuration.ddspipe_configuration.log_configuration.verbosity);
 
-            eprosima::utils::LogConfiguration log_config = router_configuration.ddspipe_configuration.log_configuration;
+            const auto log_configuration = router_configuration.ddspipe_configuration.log_configuration;
+
             eprosima::utils::Log::RegisterConsumer(
-                std::make_unique<eprosima::utils::CustomStdLogConsumer>(&log_config));
+                std::make_unique<eprosima::utils::CustomStdLogConsumer>(&log_configuration));
+
+            eprosima::utils::Log::RegisterConsumer(
+                std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(log_configuration));
 
             // NOTE:
             // It will not filter any log, so Fast DDS logs will be visible unless Fast DDS is compiled

--- a/tools/ddsrouter_tool/src/cpp/main.cpp
+++ b/tools/ddsrouter_tool/src/cpp/main.cpp
@@ -23,7 +23,7 @@
 #include <cpp_utils/event/SignalEventHandler.hpp>
 #include <cpp_utils/exception/ConfigurationException.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>
-#include <cpp_utils/logging/CustomStdLogConsumer.hpp>
+#include <cpp_utils/logging/StdLogConsumer.hpp>
 #include <cpp_utils/logging/LogConfiguration.hpp>
 #include <cpp_utils/ReturnCode.hpp>
 #include <cpp_utils/time/time_utils.hpp>
@@ -135,11 +135,19 @@ int main(
 
             const auto log_configuration = router_configuration.ddspipe_configuration.log_configuration;
 
-            eprosima::utils::Log::RegisterConsumer(
-                std::make_unique<eprosima::utils::CustomStdLogConsumer>(&log_configuration));
+            // Stdout Log Consumer
+            if (log_configuration.stdout_enable)
+            {
+                eprosima::utils::Log::RegisterConsumer(
+                    std::make_unique<eprosima::utils::StdLogConsumer>(&log_configuration));
+            }
 
-            eprosima::utils::Log::RegisterConsumer(
-                std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(log_configuration));
+            // DDS Log Consumer
+            if (log_configuration.publish.enable)
+            {
+                eprosima::utils::Log::RegisterConsumer(
+                    std::make_unique<eprosima::ddspipe::core::DdsLogConsumer>(log_configuration));
+            }
 
             // NOTE:
             // It will not filter any log, so Fast DDS logs will be visible unless Fast DDS is compiled


### PR DESCRIPTION
In this version, users can configure through the YAML the publication of Fast DDS's logs. 

Merge after:
- https://github.com/eProsima/dev-utils/pull/92
- https://github.com/eProsima/DDS-Pipe/pull/86
- https://github.com/eProsima/DDS-Router/pull/433
- https://github.com/eProsima/dev-utils/pull/97
- https://github.com/eProsima/DDS-Pipe/pull/92