### PR TITLE
Change default log configuration filter

### DIFF
--- a/ddsrouter_yaml/src/cpp/CommandlineArgsRouter.cpp
+++ b/ddsrouter_yaml/src/cpp/CommandlineArgsRouter.cpp
@@ -21,7 +21,7 @@ namespace yaml {
 CommandlineArgsRouter::CommandlineArgsRouter()
 {
     log_filter[utils::VerbosityKind::Info].set_value("DDSROUTER", utils::FuzzyLevelValues::fuzzy_level_default);
-    log_filter[utils::VerbosityKind::Warning].set_value("DDSROUTER|DDSPIPE",
+    log_filter[utils::VerbosityKind::Warning].set_value("DDSROUTER",
             utils::FuzzyLevelValues::fuzzy_level_default);
     log_filter[utils::VerbosityKind::Error].set_value("", utils::FuzzyLevelValues::fuzzy_level_default);
 }

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -397,7 +397,7 @@ Logging
 Under the ``logging`` tag, users can configure the type of logs to display and filter the logs based on their content and category.
 When configuring the verbosity to ``info``, all types of logs, including informational messages, warnings, and errors, will be displayed.
 Conversely, setting it to ``warning`` will only show warnings and errors, while choosing ``error`` will exclusively display errors.
-By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSPIPE|DDSROUTER`` and informational messages from the ``DDSROUTER`` category.
+By default, the filter allows all errors to be displayed, while selectively permitting warning messages from ``DDSROUTER`` and informational messages from the ``DDSROUTER`` category.
 
 .. code-block:: yaml
 
@@ -436,7 +436,7 @@ By default, the filter allows all errors to be displayed, while selectively perm
           or message of the logs.
         - *string*
         - info : ``DDSROUTER`` |br|
-          warning : ``DDSPIPE|DDSROUTER`` |br|
+          warning : ``DDSROUTER`` |br|
           error : ``""``
         - Regex string
 

--- a/tools/ddsrouter_tool/src/cpp/user_interface/arguments_configuration.cpp
+++ b/tools/ddsrouter_tool/src/cpp/user_interface/arguments_configuration.cpp
@@ -246,7 +246,7 @@ ProcessReturnCode parse_arguments(
 
                 case optionIndex::ACTIVATE_DEBUG:
                     commandline_args.log_filter[utils::VerbosityKind::Error].set_value("");
-                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("(DDSROUTER|DDSPIPE)");
+                    commandline_args.log_filter[utils::VerbosityKind::Warning].set_value("DDSROUTER");
                     commandline_args.log_filter[utils::VerbosityKind::Info].set_value("DDSROUTER");
                     commandline_args.log_verbosity = utils::VerbosityKind::Info;
                     break;


### PR DESCRIPTION
Change default log filter configuration in DDSRouter tool to:
          - info : ``DDSROUTER``
          - warning : ``DDSROUTER``
          - error : ``""``