### PR TITLE
Remove `secure_wan` test from the list of failing tests

### DIFF
--- a/ddsrouter_test/compose/TEST_XFAIL.list
+++ b/ddsrouter_test/compose/TEST_XFAIL.list
@@ -1,1 +1,0 @@
-tool.application.ddsrouter.compose.security_secure_wan

--- a/ddsrouter_test/compose/test_cases/security/secure_wan/compose.yml
+++ b/ddsrouter_test/compose/test_cases/security/secure_wan/compose.yml
@@ -70,7 +70,7 @@ services:
       - ./certs:/certs
     environment:
       - FASTDDS_DEFAULT_PROFILES_FILE=/configurations/configuration_local0.xml
-    command: build/fastdds_configuration_example/configuration publisher --interval 100 --samples 90 --profile-participant secure_local_0 --name topic_0
+    command: build/fastdds_configuration_example/configuration publisher --interval 100 --samples 90 --profile-participant secure_local_pub0 --name topic_0
 
   subscriber_sec_1_0:
     image: ${DDSROUTER_COMPOSE_TEST_DOCKER_IMAGE}
@@ -83,7 +83,7 @@ services:
       - ./certs:/certs
     environment:
       - FASTDDS_DEFAULT_PROFILES_FILE=/configurations/configuration_local0.xml
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe build/fastdds_configuration_example/configuration --samples 15 --timeout 12 --args "--samples 15 --name topic_1 --profile-participant secure_local_0"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe build/fastdds_configuration_example/configuration --samples 15 --timeout 12 --args "--samples 15 --name topic_1 --profile-participant secure_local_sub0"
 
 
   # LAN 1
@@ -110,7 +110,7 @@ services:
       - ./certs:/certs
     environment:
       - FASTDDS_DEFAULT_PROFILES_FILE=/configurations/configuration_local1.xml
-    command: python3 /scripts/execute_and_validate_subscriber.py --exe build/fastdds_configuration_example/configuration --samples 15 --timeout 12 --args "--samples 15 --name topic_0 --profile-participant secure_local_1"
+    command: python3 /scripts/execute_and_validate_subscriber.py --exe build/fastdds_configuration_example/configuration --samples 15 --timeout 12 --args "--samples 15 --name topic_0 --profile-participant secure_local_sub1"
 
   publisher_sec_1_1:
     image: ${DDSROUTER_COMPOSE_TEST_DOCKER_IMAGE}
@@ -122,7 +122,7 @@ services:
       - ./certs:/certs
     environment:
       - FASTDDS_DEFAULT_PROFILES_FILE=/configurations/configuration_local1.xml
-    command: build/fastdds_configuration_example/configuration publisher --interval 100 --samples 90 --profile-participant secure_local_1 --name topic_1
+    command: build/fastdds_configuration_example/configuration publisher --interval 100 --samples 90 --profile-participant secure_local_pub1 --name topic_1
 
 
   # LAN 2


### PR DESCRIPTION
The PR https://github.com/eProsima/Fast-DDS/pull/5071 fixes a known issue in Fast-DDS's security over WAN. This issue made the `secure_wan` test fail, forcing us to place it in the list of failing tests (`TEST_XFAIL`). Since the test should now pass, we will remove it from the list of failing tests.  

Merge after:
- https://github.com/eProsima/Fast-DDS/pull/5071
- https://github.com/eProsima/DDS-Router/pull/418