### PR TITLE
Correct command to load docker image from tarball

### DIFF
--- a/docs/rst/installation/docker.rst
+++ b/docs/rst/installation/docker.rst
@@ -22,7 +22,7 @@ The steps to run |ddsrouter| in a Docker container are explained below.
 
     .. code-block:: bash
 
-        load ubuntu-ddsrouter:<version>.tar
+        docker load -i ubuntu-ddsrouter\ <version>.tar
 
     where ``version`` is the downloaded version of |ddsrouter|.
 


### PR DESCRIPTION
The downloaded filename has a whitespace.
The command "load" was switched to "docker load -i ..."