### PR TITLE
 [21568] Remove yaml-cpp target library in ddsrouter tests package #468 

### DIFF
--- a/tools/ddsrouter_tool/test/application/CMakeLists.txt
+++ b/tools/ddsrouter_tool/test/application/CMakeLists.txt
@@ -96,6 +96,12 @@ if(WIN32)
 
     string(REPLACE ";" "\\;" TEST_ENVIRONMENT "${TEST_ENVIRONMENT}")
 
+else()
+
+    # yaml-cpp changed its behavior in 0.8.0 (distributed in Ubuntu-24), so that the target changed from yaml-cpp to yaml-cpp::yaml-cpp .
+    # Instead of using each of these names depending on the OS, we simply remove it since it's actually not required.
+    string(REPLACE "$<TARGET_FILE_DIR:yaml-cpp>;" "" TEST_ENVIRONMENT "${TEST_ENVIRONMENT}")
+
 endif(WIN32)
 
 # populate the tests


### PR DESCRIPTION
Some issues have been found while building DDS Router tools tests in Ubuntu 24.04 CI (see [here](https://github.com/eProsima/DDS-Router/actions/runs/10572296105/job/29289750629?pr=463#step:4:422)).