### PR TITLE
[22870] Support ROS 2 Easy Mode

### DIFF
--- a/ddsrouter_yaml/test/unittest/participants/CMakeLists.txt
+++ b/ddsrouter_yaml/test/unittest/participants/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_SOURCES
 set(TEST_LIST
         get_participant
         get_participant_negative
+        get_easy_mode_ip
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/ddsrouter_yaml/test/unittest/participants/YamlGetSimpleParticipantConfigurationTest.cpp
+++ b/ddsrouter_yaml/test/unittest/participants/YamlGetSimpleParticipantConfigurationTest.cpp
@@ -133,6 +133,35 @@ TEST(YamlGetSimpleParticipantConfigurationTest, get_participant_negative)
     }
 }
 
+TEST(YamlGetSimpleParticipantConfigurationTest, get_easy_mode_ip)
+{
+    ddsrouter::core::types::ParticipantKind kind = ddsrouter::core::types::ParticipantKind::simple;
+    ddspipe::core::types::ParticipantId id = ddspipe::core::testing::random_participant_id();
+    ddspipe::core::types::DomainId domain;
+    ddspipe::participants::types::IpType easy_mode_ip = "127.0.0.1";
+
+    // Create a configuration with this kind and this id
+    Yaml yml;
+    Yaml yml_participant;
+
+
+    ddspipe::yaml::testing::participantid_to_yaml(yml_participant, id);
+    ddsrouter::yaml::testing::participantkind_to_yaml(yml_participant, kind);
+    ddspipe::yaml::testing::domain_to_yaml(yml_participant, domain);
+    ddspipe::yaml::testing::easy_mode_ip_to_yaml(yml_participant, easy_mode_ip);
+
+    yml["participant"] = yml_participant;
+
+    // Read Yaml
+    ddspipe::participants::SimpleParticipantConfiguration result =
+            ddspipe::yaml::YamlReader::get<ddspipe::participants::SimpleParticipantConfiguration>(yml,
+                    "participant",
+                    ddspipe::yaml::YamlReaderVersion::LATEST);
+
+    // Check result
+    ASSERT_EQ(easy_mode_ip, result.easy_mode_ip);
+}
+
 int main(
         int argc,
         char** argv)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,7 +243,7 @@ release = u'{}.{}.{}'.format(
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -5,3 +5,9 @@
 ###################
 Forthcoming Version
 ###################
+
+This release include the following **major changes**:
+
+* Add support to configure ROS 2 Easy Mode in the *yaml* configuration file.
+
+  - New ``ros2-easy-mode`` tag added.

--- a/docs/rst/notes/forthcoming_version.rst
+++ b/docs/rst/notes/forthcoming_version.rst
@@ -6,8 +6,8 @@
 Forthcoming Version
 ###################
 
-This release include the following **major changes**:
+Next release will include the following **major changes**:
 
 * Add support to configure ROS 2 Easy Mode in the *yaml* configuration file.
 
-  - New ``ros2-easy-mode`` tag added.
+  - New ``ros2-easy-mode`` tag added. Check :ref:`user_manual_configuration_easy_mode` section.

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -2,7 +2,7 @@
 
 .. _release_notes:
 
-.. .. include:: forthcoming_version.rst
+.. include:: forthcoming_version.rst
 
 ##############
 Version v3.1.0

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -662,7 +662,7 @@ through the ``ros2-easy-mode`` tag:
 
 .. warning::
     This configuration is incompatible with the ``transports`` tag.
-    Setting ``ros2-easy-mode`` along with ``transports: udp`` or ``transports: shm``
+    Setting ``ros2-easy-mode`` other than ``transports: builtin``
     will prevent Easy Mode from being configured.
 
     For now, only IPv4 addresses are supported.
@@ -1089,10 +1089,6 @@ A complete example of all the configurations described on this page can be found
         kind: simple                     # Participant Kind = local (= simple)
 
         domain: 7                       # DomainId = 7
-
-        qos:
-
-          max-rx-rate: 15                 # Max Reception Rate = 15
 
         ros2-easy-mode: "2.2.2.2"        # Remote discovery server address
 

--- a/docs/rst/user_manual/configuration.rst
+++ b/docs/rst/user_manual/configuration.rst
@@ -646,6 +646,26 @@ However, a user may desire to force the use of one of the two, which can be acco
 
     Participants configured with ``transport: shm`` will only communicate with applications using Shared Memory Transport exclusively (with disabled UDP transport).
 
+.. _user_manual_configuration_easy_mode:
+
+ROS 2 Easy Mode Configuration
+-----------------------------
+
+DDS Router allows configuring the address of a remote discovery server when using
+:ref:`Simple Participants <user_manual_participants_simple>` with
+`ROS 2 Easy Mode <https://docs.vulcanexus.org/en/latest/rst/enhancements/easy_mode/easy_mode.html>`__
+through the ``ros2-easy-mode`` tag:
+
+.. code-block:: yaml
+
+    ros2-easy-mode: "2.2.2.2"       # Remote discovery server address
+
+.. warning::
+    This configuration is incompatible with the ``transports`` tag.
+    Setting ``ros2-easy-mode`` along with ``transports: udp`` or ``transports: shm``
+    will prevent Easy Mode from being configured.
+
+    For now, only IPv4 addresses are supported.
 
 .. _user_manual_configuration_interface_whitelist:
 
@@ -1059,6 +1079,22 @@ A complete example of all the configurations described on this page can be found
         qos:
 
           max-rx-rate: 15                 # Max Reception Rate = 15
+
+    ####################
+
+    # Simple DDS Participant configured with ROS 2 Easy Mode
+
+      - name: Participant1              # Participant Name = Participant1
+
+        kind: simple                     # Participant Kind = local (= simple)
+
+        domain: 7                       # DomainId = 7
+
+        qos:
+
+          max-rx-rate: 15                 # Max Reception Rate = 15
+
+        ros2-easy-mode: "2.2.2.2"        # Remote discovery server address
 
     ####################
 


### PR DESCRIPTION
# Main Changes

This PR adds documentation for the new `ros2-easy-mode` tag, which allows configuring the IP of the remote Discovery Server when using Easy Mode. A unit test was added to verify the correct parsing of the attribute.

This PR must be merged after:
- https://github.com/eProsima/DDS-Pipe/pull/139