### PR TITLE
[21670] Fix failing tests in Router 2.x

### DIFF
--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/WAN/DDSTestWAN.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/WAN/DDSTestWAN.cpp
@@ -128,6 +128,13 @@ discovery_server_participant_configuration(
             );
     }
 
+    // Localhost translation is never accomplished in DS with Fast DDS 2.x due to fixed GUIDs.
+    // TCPv6 suffers from this issue as it will not be able to make any connection. A whitelist is needed to enforce
+    // localhost connections.
+    // This issue is fixed in Fast DDS 3.x with machine_id based translations and non-fixed GUIDs DS's.
+    participants::types::WhitelistType lo_wl = (ip_version == participants::types::IpVersion::v4 ? "127.0.0.1" : "::1");
+    conf.whitelist.insert(lo_wl);
+
     conf.id = core::types::ParticipantId("WanDsParticipant_" + std::to_string((this_server_id_is_1 ? 1 : 0)));
 
     conf.discovery_server_guid_prefix = core::types::GuidPrefix((this_server_id_is_1 ? 1u : 0u));

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
@@ -286,10 +286,6 @@ public:
     {
         if (participant_ != nullptr)
         {
-            if (topic_ != nullptr)
-            {
-                participant_->delete_topic(topic_);
-            }
             if (subscriber_ != nullptr)
             {
                 if (reader_ != nullptr)
@@ -297,6 +293,10 @@ public:
                     subscriber_->delete_datareader(reader_);
                 }
                 participant_->delete_subscriber(subscriber_);
+            }
+            if (topic_ != nullptr)
+            {
+                participant_->delete_topic(topic_);
             }
             eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(participant_);
         }


### PR DESCRIPTION
This PR modifies the order in the destructor of `TestSubscriber`, which avoids a case in which running several `test_WAN_communication` in a row resulted in no communication.

It also adds whitelist for Discovery Server routers tests. This is needed because locators transformation is never accomplished with Discovery Servers in Fast DDS 2.x due to fixed GUIDs. This forces extra channels creations for TCP, but most important it does not rely on localhost for communication, which results in errors for TCPv6. By adding a whitelist this problem is avoided. 
The fix to this issue was solved in Fast DDS 3.x by adding the `machine_id` field and non-fixed GUIDs for Discovery Servers.