### PR TITLE
[21670] Use 'Debug' binaries for TSAN tests

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -108,7 +108,7 @@ jobs:
         uses: ./src/.github/actions/project_dependencies
         with:
           os: ubuntu-22.04
-          cmake_build_type: Release
+          cmake_build_type: Debug
           custom_version_build: ${{ inputs.custom_version_build }}
           dependencies_artifact_postfix: ${{ inputs.dependencies_artifact_postfix }}
           secret_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR modifies the github action definition of TSAN tests to use the `Debug` binaries instead of the `Release` ones and also rely on the tsan binary created for both DDS Pipe and Fast DDS.

- This PR must be merged after https://github.com/eProsima/eProsima-CI/pull/150