### PR TITLE
Use different Vulcanexus images for each Fast DDS version

### DIFF
--- a/.github/docker/vulcanexus/Dockerfile
+++ b/.github/docker/vulcanexus/Dockerfile
@@ -16,12 +16,6 @@ SHELL ["/bin/bash", "-c"]
 ARG docker_image_base
 RUN echo "Docker Base image used: ${docker_image_base}"
 
-# TODO: Remove once external issue is solved
-# Update ROS 2 keys (not updated in the base image as of June 2025)
-RUN rm /etc/apt/sources.list.d/ros2-latest.list && \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
 # Install message interface and demo nodes required packages
 RUN source "/opt/vulcanexus/$VULCANEXUS_DISTRO/setup.bash" && \
         apt-get update && \

--- a/.github/workflows/docker-reusable-workflow.yml
+++ b/.github/workflows/docker-reusable-workflow.yml
@@ -65,6 +65,7 @@ jobs:
     env:
       DDSROUTER_COMPOSE_TEST_DOCKER_IMAGE: "ddsrouter:ci"
       DDSROUTER_COMPOSE_TEST_ROS2_DOCKER_IMAGE: "vulcanexus:ci"
+      VULCANEXUS_IMAGE: ${{ startsWith(inputs.fastdds_branch, '2.') && 'eprosima/vulcanexus:humble-core' || 'eprosima/vulcanexus:jazzy-core' }}
 
     steps:
 
@@ -80,7 +81,7 @@ jobs:
           cd ./src/.github/docker/vulcanexus
           docker build \
             --no-cache \
-            --build-arg docker_image_base=eprosima/vulcanexus:jazzy-core \
+            --build-arg docker_image_base=${{ env.VULCANEXUS_IMAGE }} \
             -t ${{ env.DDSROUTER_COMPOSE_TEST_ROS2_DOCKER_IMAGE }} \
             -f Dockerfile .
 


### PR DESCRIPTION
This PR selects the Vulcanexus base image used for testing according the Fast DDS version used.

It also removes the temporary workaround introduced in https://github.com/eProsima/DDS-Router/pull/510 to fix ROS 2 apt keys.

It must be merged after rebuilding all docker images.