### PR TITLE
[23573] Adding tests for original writer forwarding

### DIFF
--- a/ddsrouter.repos
+++ b/ddsrouter.repos
@@ -6,20 +6,20 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: 2.x
+        version: 2.3.0
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: 3.x
+        version: 3.3.0
     dev-utils:
         type: git
         url: https://github.com/eProsima/dev-utils.git
-        version: 1.x
+        version: 1.3.0
     ddspipe:
         type: git
         url: https://github.com/eProsima/DDS-Pipe.git
-        version: 1.x
+        version: 1.3.0
     ddsrouter:
         type: git
         url: https://github.com/eProsima/DDS-Router.git
-        version: main
+        version: 3.3.0

--- a/ddsrouter.repos
+++ b/ddsrouter.repos
@@ -6,20 +6,20 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: 2.3.0
+        version: v2.3.0
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: 3.3.0
+        version: v3.3.0
     dev-utils:
         type: git
         url: https://github.com/eProsima/dev-utils.git
-        version: 1.3.0
+        version: v1.3.0
     ddspipe:
         type: git
         url: https://github.com/eProsima/DDS-Pipe.git
-        version: 1.3.0
+        version: v1.3.0
     ddsrouter:
         type: git
         url: https://github.com/eProsima/DDS-Router.git
-        version: 3.3.0
+        version: v3.3.0

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
@@ -83,7 +83,8 @@ DdsRouterConfiguration dds_test_simple_configuration(
         topic_keyed.type_name = "HelloWorldKeyed";
         topic_keyed.topic_qos.keyed = true;
 
-        conf.ddspipe_configuration.builtin_topics.insert(utils::Heritable<core::types::DdsTopic>::make_heritable(topic));
+        conf.ddspipe_configuration.builtin_topics.insert(utils::Heritable<core::types::DdsTopic>::make_heritable(
+                    topic));
         conf.ddspipe_configuration.builtin_topics.insert(utils::Heritable<core::types::DdsTopic>::make_heritable(
                     topic_keyed));
     }
@@ -239,7 +240,9 @@ void test_original_writer_forwarding(
     sent_msg.index(samples_sent);
     ASSERT_EQ(publisher.publish(sent_msg), eprosima::fastdds::dds::RETCODE_OK);
     // Watiting for the message to be received
-    while(samples_received.load() < 1){};
+    while (samples_received.load() < 1)
+    {
+    }
     ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
 
     // CASE 2: Send message with original_writer_param set to unknown, should be set to other value
@@ -248,7 +251,9 @@ void test_original_writer_forwarding(
     params.original_writer_guid(eprosima::fastdds::rtps::GUID_t::unknown());
     ASSERT_EQ(publisher.publish_with_params(sent_msg, params), eprosima::fastdds::dds::RETCODE_OK);
     // Watiting for the message to be received
-    while(samples_received.load() < 2){};
+    while (samples_received.load() < 2)
+    {
+    }
     ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
 
     // CASE 3: Send message with original_writer_param set to some value, value must be kept
@@ -258,12 +263,13 @@ void test_original_writer_forwarding(
     params_with_og_writer.original_writer_guid(guid);
     ASSERT_EQ(publisher.publish_with_params(sent_msg, params_with_og_writer), eprosima::fastdds::dds::RETCODE_OK);
     // Watiting for the message to be received
-    while(samples_received.load() < 2){};
+    while (samples_received.load() < 2)
+    {
+    }
     ASSERT_EQ(subscriber.original_writer_guid(), guid);
 
     router.stop();
 }
-
 
 } /* namespace test */
 

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
@@ -154,7 +154,8 @@ public:
 
     //! Publish a sample with parameters
     eprosima::fastdds::dds::ReturnCode_t publish_with_params(
-        MsgStruct msg, eprosima::fastdds::rtps::WriteParams params)
+            MsgStruct msg,
+            eprosima::fastdds::rtps::WriteParams params)
     {
         hello_.index(msg.index());
         hello_.message(msg.message());
@@ -228,7 +229,6 @@ private:
                 discovered = info.current_count;
             }
         }
-
 
     private:
 

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
@@ -152,6 +152,17 @@ public:
         return writer_->write(&hello_);
     }
 
+    //! Publish a sample with parameters
+    eprosima::fastdds::dds::ReturnCode_t publish_with_params(
+        MsgStruct msg, eprosima::fastdds::rtps::WriteParams params)
+    {
+        hello_.index(msg.index());
+        hello_.message(msg.message());
+
+
+        return writer_->write(&hello_, params);
+    }
+
     //! Dispose instance
     eprosima::fastdds::dds::ReturnCode_t dispose_key(
             MsgStruct msg);
@@ -160,6 +171,11 @@ public:
             uint32_t n_subscribers = 1)
     {
         listener_.wait_discovery(n_subscribers);
+    }
+
+    eprosima::fastdds::rtps::GUID_t original_writer_guid() const
+    {
+        return writer_->guid();
     }
 
 private:
@@ -212,6 +228,7 @@ private:
                 discovered = info.current_count;
             }
         }
+
 
     private:
 
@@ -357,6 +374,11 @@ public:
         return listener_.n_key_disposed;
     }
 
+    eprosima::fastdds::rtps::GUID_t original_writer_guid() const
+    {
+        return listener_.original_writer_guid;
+    }
+
 private:
 
     eprosima::fastdds::dds::DomainParticipant* participant_;
@@ -424,6 +446,8 @@ private:
                 {
                     n_key_disposed++;
                 }
+
+                original_writer_guid = iHandle2GUID(info.original_publication_handle);
             }
         }
 
@@ -444,6 +468,9 @@ private:
 
         //! Placeholder where received data is stored
         MsgStruct msg_received;
+
+        //! Placeholder where original writer GUID is stored
+        eprosima::fastdds::rtps::GUID_t original_writer_guid;
 
         std::atomic<std::uint32_t> n_key_disposed;
 

--- a/docs/resources/use_cases/ros_cloud/Dockerfile_ddsrouter
+++ b/docs/resources/use_cases/ros_cloud/Dockerfile_ddsrouter
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 
 # Download and build DDS-Router
 RUN mkdir resources && \
-    wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos && \
+    wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos && \
     mkdir src && \
     vcs import src < ddsrouter.repos && \
     colcon build --event-handlers=console_direct+

--- a/docs/resources/use_cases/ros_cloud/Dockerfile_ddsrouter_logon
+++ b/docs/resources/use_cases/ros_cloud/Dockerfile_ddsrouter_logon
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 
 # Download and build DDS-Router
 RUN mkdir resources && \
-    wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos && \
+    wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos && \
     mkdir src && \
     vcs import src < ddsrouter.repos && \
     colcon build --event-handlers=console_direct+ --cmake-args -DLOG_INFO=ON

--- a/docs/rst/developer_manual/installation/sources/linux.rst
+++ b/docs/rst/developer_manual/installation/sources/linux.rst
@@ -214,7 +214,7 @@ Colcon installation
 
         mkdir -p ~/DDS-Router/src
         cd ~/DDS-Router
-        wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos
+        wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos
         vcs import src < ddsrouter.repos
 
     .. note::
@@ -258,7 +258,7 @@ Local installation
         mkdir -p ~/DDS-Router/src
         mkdir -p ~/DDS-Router/build
         cd ~/DDS-Router
-        wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos
+        wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos
         vcs import src < ddsrouter.repos
 
 #.  Compile all dependencies using CMake_.

--- a/docs/rst/developer_manual/installation/sources/windows.rst
+++ b/docs/rst/developer_manual/installation/sources/windows.rst
@@ -257,7 +257,7 @@ Colcon installation
         mkdir <path\to\user\workspace>\DDS-Router
         cd <path\to\user\workspace>\DDS-Router
         mkdir src
-        wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos
+        wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos
         vcs import src --input ddsrouter.repos
 
     .. note::
@@ -309,7 +309,7 @@ Local installation
         mkdir <path\to\user\workspace>\DDS-Router\src
         mkdir <path\to\user\workspace>\DDS-Router\build
         cd <path\to\user\workspace>\DDS-Router
-        wget https://raw.githubusercontent.com/eProsima/DDS-Router/main/ddsrouter.repos
+        wget https://raw.githubusercontent.com/eProsima/DDS-Router/v3.3.0/ddsrouter.repos
         vcs import src --input ddsrouter.repos
 
 #.  Compile all dependencies using CMake_.

--- a/docs/rst/use_cases/ros_cloud.rst
+++ b/docs/rst/use_cases/ros_cloud.rst
@@ -124,7 +124,7 @@ the previously set up ConfigMap. This Docker image needs to be built and made av
 |ddsrouter|, which can be accomplished by providing the following
 :download:`Dockerfile <../../resources/use_cases/ros_cloud/Dockerfile_ddsrouter>`. If willing to see log messages in
 ``STDOUT``, use :download:`Dockerfile <../../resources/use_cases/ros_cloud/Dockerfile_ddsrouter_logon>` instead.
-Assuming the name of the generated Docker image is ``ddsrouter:main``, the cloud router will then be deployed with the
+Assuming the name of the generated Docker image is ``ddsrouter:v3.3.0``, the cloud router will then be deployed with the
 following settings:
 
 .. literalinclude:: ../../resources/use_cases/ros_cloud/ddsrouter.yaml


### PR DESCRIPTION
Adds 2 blackbox tests:

- dds-pipe sets the original writer when the original writer is unknown
- dds-pipe keeps the original writer when it is known


This PR depends on https://github.com/eProsima/DDS-Pipe/pull/163 and must be merged after it.