### PR TITLE
[23573] Add blackbox tests for original writer info in ddspipe

### DIFF
--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/CMakeLists.txt
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/CMakeLists.txt
@@ -37,7 +37,8 @@ set(TEST_LIST
     end_to_end_local_communication_high_size
     end_to_end_local_communication_high_throughput
     end_to_end_local_communication_transient_local
-    end_to_end_local_communication_transient_local_disable_dynamic_discovery)
+    end_to_end_local_communication_transient_local_disable_dynamic_discovery,
+    end_to_end_local_communication_original_writer_forwarding)
 
 set(TEST_NEEDED_SOURCES
     )

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
@@ -206,7 +206,6 @@ void test_local_communication(
     router.stop();
 }
 
-
 template <class MsgStruct, class MsgStructType>
 void test_original_writer_forwarding(
         DdsRouterConfiguration ddsrouter_configuration)
@@ -215,7 +214,6 @@ void test_original_writer_forwarding(
 
     uint32_t samples_sent = 0;
     std::atomic<uint32_t> samples_received(0);
-    std::atomic<uint32_t> samples_to_receive(1);
 
     MsgStruct sent_msg;
     MsgStructType type;
@@ -266,7 +264,6 @@ void test_original_writer_forwarding(
     {
     }
     ASSERT_EQ(subscriber.original_writer_guid(), guid);
-
 
     router.stop();
 }

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
@@ -242,18 +242,7 @@ void test_original_writer_forwarding(
     }
     ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
 
-    // CASE 2: Send message with original_writer_param set to unknown, should be set to other value
-    sent_msg.index(++samples_sent);
-    eprosima::fastdds::rtps::WriteParams params;
-    params.original_writer_info(eprosima::fastdds::rtps::OriginalWriterInfo::unknown());
-    ASSERT_EQ(publisher.publish_with_params(sent_msg, params), eprosima::fastdds::dds::RETCODE_OK);
-    // Waiting for the message to be received
-    while (samples_received.load() < 2)
-    {
-    }
-    ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
-
-    // CASE 3: Send message with original_writer_param set to some value, value must be kept
+    // CASE 2: Send message with original_writer_param set to some value, value must be kept
     sent_msg.index(++samples_sent);
     eprosima::fastdds::rtps::WriteParams params_with_og_writer;
     eprosima::fastdds::rtps::GUID_t guid({}, 0x12345678);
@@ -264,6 +253,17 @@ void test_original_writer_forwarding(
     {
     }
     ASSERT_EQ(subscriber.original_writer_guid(), guid);
+
+    // CASE 3: Send message with original_writer_param set to unknown, should be set to other value
+    sent_msg.index(++samples_sent);
+    eprosima::fastdds::rtps::WriteParams params;
+    params.original_writer_info(eprosima::fastdds::rtps::OriginalWriterInfo::unknown());
+    ASSERT_EQ(publisher.publish_with_params(sent_msg, params), eprosima::fastdds::dds::RETCODE_OK);
+    // Waiting for the message to be received
+    while (samples_received.load() < 2)
+    {
+    }
+    ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
 
     router.stop();
 }

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
@@ -206,6 +206,71 @@ void test_local_communication(
     router.stop();
 }
 
+
+template <class MsgStruct, class MsgStructType>
+void test_original_writer_forwarding(
+        DdsRouterConfiguration ddsrouter_configuration)
+{
+    INSTANTIATE_LOG_TESTER(eprosima::utils::Log::Kind::Error, 0, 0);
+
+    uint32_t samples_sent = 0;
+    std::atomic<uint32_t> samples_received(0);
+    std::atomic<uint32_t> samples_to_receive(1);
+
+    MsgStruct sent_msg;
+    MsgStructType type;
+    std::string msg_str;
+    msg_str += "Testing DdsRouter Blackbox Local Communication ...";
+    sent_msg.message(msg_str);
+    // Create DDS Publisher in domain 0
+    TestPublisher<MsgStruct> publisher(type.is_compute_key_provided);
+
+    ASSERT_TRUE(publisher.init(0));
+
+    // Create DDS Subscriber in domain 1
+    TestSubscriber<MsgStruct> subscriber(type.is_compute_key_provided, true);
+    ASSERT_TRUE(subscriber.init(1, &sent_msg, &samples_received));
+
+    // Create DdsRouter entity
+    DdsRouter router(ddsrouter_configuration);
+    router.start();
+
+    // CASE 1: Send message without original_writer_param, should be set to writers guid
+    sent_msg.index(++samples_sent);
+    ASSERT_EQ(publisher.publish(sent_msg), eprosima::fastdds::dds::RETCODE_OK);
+    // Watiting for the message to be received
+    while (samples_received.load() < 1)
+    {
+    }
+    ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
+
+    // CASE 2: Send message with original_writer_param set to unknown, should be set to other value
+    sent_msg.index(++samples_sent);
+    eprosima::fastdds::rtps::WriteParams params;
+    params.original_writer_info(eprosima::fastdds::rtps::OriginalWriterInfo::unknown());
+    ASSERT_EQ(publisher.publish_with_params(sent_msg, params), eprosima::fastdds::dds::RETCODE_OK);
+    // Waiting for the message to be received
+    while (samples_received.load() < 2)
+    {
+    }
+    ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());
+
+    // CASE 3: Send message with original_writer_param set to some value, value must be kept
+    sent_msg.index(++samples_sent);
+    eprosima::fastdds::rtps::WriteParams params_with_og_writer;
+    eprosima::fastdds::rtps::GUID_t guid({}, 0x12345678);
+    params_with_og_writer.original_writer_info().original_writer_guid(guid);
+    ASSERT_EQ(publisher.publish_with_params(sent_msg, params_with_og_writer), eprosima::fastdds::dds::RETCODE_OK);
+    // Waiting for the message to be received
+    while (samples_received.load() < 3)
+    {
+    }
+    ASSERT_EQ(subscriber.original_writer_guid(), guid);
+
+
+    router.stop();
+}
+
 } /* namespace test */
 
 /**
@@ -320,6 +385,16 @@ TEST(DDSTestLocal, end_to_end_local_communication_transient_local_disable_dynami
         test::DEFAULT_MILLISECONDS_PUBLISH_LOOP,
         test::DEFAULT_MESSAGE_SIZE,
         true);
+}
+
+/**
+ * Test original writer forwarding in HelloWorld topic between two DDS participants created in different domains,
+ * by using a router with two Simple Participants at each domain.
+ */
+TEST(DDSTestLocal, end_to_end_local_communication_original_writer_forwarding)
+{
+    test::test_original_writer_forwarding<HelloWorld, HelloWorldPubSubType>(
+        test::dds_test_simple_configuration());
 }
 
 int main(

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/local/DDSTestLocal.cpp
@@ -249,7 +249,7 @@ void test_original_writer_forwarding(
     params_with_og_writer.original_writer_info().original_writer_guid(guid);
     ASSERT_EQ(publisher.publish_with_params(sent_msg, params_with_og_writer), eprosima::fastdds::dds::RETCODE_OK);
     // Waiting for the message to be received
-    while (samples_received.load() < 3)
+    while (samples_received.load() < 2)
     {
     }
     ASSERT_EQ(subscriber.original_writer_guid(), guid);
@@ -260,7 +260,7 @@ void test_original_writer_forwarding(
     params.original_writer_info(eprosima::fastdds::rtps::OriginalWriterInfo::unknown());
     ASSERT_EQ(publisher.publish_with_params(sent_msg, params), eprosima::fastdds::dds::RETCODE_OK);
     // Waiting for the message to be received
-    while (samples_received.load() < 2)
+    while (samples_received.load() < 3)
     {
     }
     ASSERT_EQ(subscriber.original_writer_guid(), publisher.original_writer_guid());

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
@@ -152,6 +152,18 @@ public:
         return writer_->write(&hello_);
     }
 
+    //! Publish a sample with parameters
+    eprosima::fastdds::dds::ReturnCode_t publish_with_params(
+            MsgStruct msg,
+            eprosima::fastdds::rtps::WriteParams params)
+    {
+        hello_.index(msg.index());
+        hello_.message(msg.message());
+
+
+        return writer_->write(&hello_, params);
+    }
+
     //! Dispose instance
     eprosima::fastdds::dds::ReturnCode_t dispose_key(
             MsgStruct msg);
@@ -160,6 +172,11 @@ public:
             uint32_t n_subscribers = 1)
     {
         listener_.wait_discovery(n_subscribers);
+    }
+
+    eprosima::fastdds::rtps::GUID_t original_writer_guid() const
+    {
+        return writer_->guid();
     }
 
 private:
@@ -357,6 +374,11 @@ public:
         return listener_.n_key_disposed;
     }
 
+    eprosima::fastdds::rtps::GUID_t original_writer_guid() const
+    {
+        return listener_.original_writer_guid;
+    }
+
 private:
 
     eprosima::fastdds::dds::DomainParticipant* participant_;
@@ -424,6 +446,8 @@ private:
                 {
                     n_key_disposed++;
                 }
+
+                original_writer_guid = info.original_writer_info.original_writer_guid();
             }
         }
 
@@ -444,6 +468,9 @@ private:
 
         //! Placeholder where received data is stored
         MsgStruct msg_received;
+
+        //! Placeholder where original writer GUID is stored
+        eprosima::fastdds::rtps::GUID_t original_writer_guid;
 
         std::atomic<std::uint32_t> n_key_disposed;
 

--- a/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
+++ b/ddsrouter_core/test/blackbox/ddsrouter_core/dds/types/test_participants.hpp
@@ -160,7 +160,6 @@ public:
         hello_.index(msg.index());
         hello_.message(msg.message());
 
-
         return writer_->write(&hello_, params);
     }
 


### PR DESCRIPTION
Adds a blackbox test that checks that:

* dds-pipe sets the original writer when the original writer is unknown
* dds-pipe keeps the original writer when it is known

This PR depends on https://github.com/eProsima/DDS-Pipe/pull/163 and must be merged after it.